### PR TITLE
imports: Use relative imports as in other modules

### DIFF
--- a/dataikuapi/dss/job.py
+++ b/dataikuapi/dss/job.py
@@ -1,6 +1,6 @@
 import time
 import sys
-from dataikuapi.utils import DataikuException
+from ..utils import DataikuException
 
 class DSSJob(object):
     """

--- a/dataikuapi/dss/macro.py
+++ b/dataikuapi/dss/macro.py
@@ -1,6 +1,6 @@
 import time
 import sys, json
-from dataikuapi.utils import DataikuException
+from ..utils import DataikuException
 
 class DSSMacro(object):
     """

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -15,7 +15,7 @@ from .wiki import DSSWiki
 from .discussion import DSSObjectDiscussions
 from .ml import DSSMLTask
 from .analysis import DSSAnalysis
-from dataikuapi.utils import DataikuException
+from ..utils import DataikuException
 
 
 class DSSProject(object):

--- a/dataikuapi/dss/scenario.py
+++ b/dataikuapi/dss/scenario.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import time
-from dataikuapi.utils import DataikuException
+from ..utils import DataikuException
 from .discussion import DSSObjectDiscussions
 
 

--- a/dataikuapi/dss/wiki.py
+++ b/dataikuapi/dss/wiki.py
@@ -1,5 +1,5 @@
 from .discussion import DSSObjectDiscussions
-from dataikuapi.utils import DataikuException
+from ..utils import DataikuException
 import json
 import sys
 import copy


### PR DESCRIPTION
Other modules use relative imports for this file.

This change is required to have the API shipped as `module_utils` in Ansible use cases.