### PR TITLE
Adding delete_versions to the saved model API.

### DIFF
--- a/dataikuapi/dss/savedmodel.py
+++ b/dataikuapi/dss/savedmodel.py
@@ -1,10 +1,8 @@
-from ..utils import DataikuException
-from ..utils import DataikuUTF8CSVReader
-from ..utils import DataikuStreamedHttpUTF8CSVReader
-import json
 from .ml import DSSTrainedPredictionModelDetails, DSSTrainedClusteringModelDetails
 from .metrics import ComputedMetrics
-from .discussion import DSSObjectDiscussions
+from .ml import DSSTrainedClusteringModelDetails
+from .ml import DSSTrainedPredictionModelDetails
+
 
 class DSSSavedModel(object):
     """
@@ -79,12 +77,13 @@ class DSSSavedModel(object):
         model, an intermediate version is created every time a partition has finished training.
         :type remove_intermediate: bool
         """
+        body = {
+            "versions": versions,
+            "removeIntermediate": remove_intermediate
+        }
         self.client._perform_empty(
             "POST", "/projects/%s/savedmodels/%s/actions/delete-versions" % (self.project_key, self.sm_id),
-            params={
-                'versions': versions,
-                'removeIntermediate': remove_intermediate
-            })
+            body=body)
     ########################################################
     # Metrics
     ########################################################

--- a/dataikuapi/dss/savedmodel.py
+++ b/dataikuapi/dss/savedmodel.py
@@ -82,7 +82,7 @@ class DSSSavedModel(object):
         self.client._perform_empty(
             "POST", "/projects/%s/savedmodels/%s/actions/delete-versions" % (self.project_key, self.sm_id),
             params={
-                'versions': json.dumps(versions),
+                'versions': versions,
                 'removeIntermediate': remove_intermediate
             })
     ########################################################

--- a/dataikuapi/dss/savedmodel.py
+++ b/dataikuapi/dss/savedmodel.py
@@ -69,6 +69,22 @@ class DSSSavedModel(object):
         self.client._perform_empty(
             "POST", "/projects/%s/savedmodels/%s/versions/%s/actions/setActive" % (self.project_key, self.sm_id, version_id))
 
+    def delete_versions(self, versions, remove_intermediate=True):
+        """
+        Delete version(s) of the saved model
+
+        :param versions: list of versions to delete
+        :type versions: list[str]
+        :param remove_intermediate: also remove intermediate versions (default: True). In the case of a partitioned
+        model, an intermediate version is created every time a partition has finished training.
+        :type remove_intermediate: bool
+        """
+        self.client._perform_empty(
+            "POST", "/projects/%s/savedmodels/%s/actions/delete-versions" % (self.project_key, self.sm_id),
+            params={
+                'versions': json.dumps(versions),
+                'removeIntermediate': remove_intermediate
+            })
     ########################################################
     # Metrics
     ########################################################

--- a/dataikuapi/dss/savedmodel.py
+++ b/dataikuapi/dss/savedmodel.py
@@ -77,6 +77,8 @@ class DSSSavedModel(object):
         model, an intermediate version is created every time a partition has finished training.
         :type remove_intermediate: bool
         """
+        if not isinstance(versions, list):
+            versions = [versions]
         body = {
             "versions": versions,
             "removeIntermediate": remove_intermediate


### PR DESCRIPTION
Adding a `delete_versions` method to `DSSSavedModel`.

See https://github.com/dataiku/dip/pull/10513 for background.