### PR TITLE
Add Ansible Galaxy metadata.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,9 @@
+---
+galaxy_info:
+  author: Dataiku
+  description: Dataiku API Client
+  company: Dataiku
+  license: Apache 2.0
+  min_ansible_version: 2.5
+  galaxy_tags: ["dataiku","dss","data-science-studio"]
+dependencies: []


### PR DESCRIPTION
This makes the package installable by `ansible-galaxy` directly.