### PR TITLE
Added redetect flag to ML task guess public API

### DIFF
--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -1690,6 +1690,7 @@ class DSSMLTask(object):
         """
         Guess the feature handling and the algorithms.
         :param string prediction_type: In case of a prediction problem the prediction type can be specify. Valid values are BINARY_CLASSIFICATION, REGRESSION, MULTICLASS.
+        :param bool redetect: if True then the DSS automatically initializes ML task settings, if False, only the target values are remapped
         """
         obj = {}
         if prediction_type is not None:

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -1686,7 +1686,7 @@ class DSSMLTask(object):
             "POST", "/projects/%s/models/lab/%s/%s/models/%s/actions/redeployToFlow" % (self.project_key, self.analysis_id, self.mltask_id, model_id),
             body = obj)
 
-    def guess(self, prediction_type=None):
+    def guess(self, prediction_type=None, redetect=None):
         """
         Guess the feature handling and the algorithms.
         :param string prediction_type: In case of a prediction problem the prediction type can be specify. Valid values are BINARY_CLASSIFICATION, REGRESSION, MULTICLASS.
@@ -1694,7 +1694,8 @@ class DSSMLTask(object):
         obj = {}
         if prediction_type is not None:
             obj["predictionType"] = prediction_type
-
+        if redetect is not None:
+            obj["redetect"] = redetect
         self.client._perform_empty(
             "PUT",
             "/projects/%s/models/lab/%s/%s/guess" % (self.project_key, self.analysis_id, self.mltask_id),

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -1686,17 +1686,19 @@ class DSSMLTask(object):
             "POST", "/projects/%s/models/lab/%s/%s/models/%s/actions/redeployToFlow" % (self.project_key, self.analysis_id, self.mltask_id, model_id),
             body = obj)
 
-    def guess(self, prediction_type=None, redetect=None):
+    def guess(self, prediction_type=None, target_only=None):
         """
         Guess the feature handling and the algorithms.
         :param string prediction_type: In case of a prediction problem the prediction type can be specify. Valid values are BINARY_CLASSIFICATION, REGRESSION, MULTICLASS.
-        :param bool redetect: if False then skip ML task settings automatic detection, only the target values are remapped
+        :param bool target_only: if True then skip ML task settings automatic detection, only the target values are remapped. Only valid for prediction ML Tasks.
         """
         obj = {}
         if prediction_type is not None:
             obj["predictionType"] = prediction_type
-        if redetect is not None:
-            obj["redetect"] = redetect
+
+        if target_only is not None:
+            obj["targetOnly"] = target_only
+
         self.client._perform_empty(
             "PUT",
             "/projects/%s/models/lab/%s/%s/guess" % (self.project_key, self.analysis_id, self.mltask_id),

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -1690,7 +1690,7 @@ class DSSMLTask(object):
         """
         Guess the feature handling and the algorithms.
         :param string prediction_type: In case of a prediction problem the prediction type can be specify. Valid values are BINARY_CLASSIFICATION, REGRESSION, MULTICLASS.
-        :param bool redetect: if True then the DSS automatically initializes ML task settings, if False, only the target values are remapped
+        :param bool redetect: if False then skip ML task settings automatic detection, only the target values are remapped
         """
         obj = {}
         if prediction_type is not None:

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -1690,7 +1690,7 @@ class DSSMLTask(object):
         """
         Guess the feature handling and the algorithms.
         :param string prediction_type: In case of a prediction problem the prediction type can be specify. Valid values are BINARY_CLASSIFICATION, REGRESSION, MULTICLASS.
-        :param bool reguess_level: One of the following values: TARGET_CHANGE, TARGET_REGUESS and FULL_REGUESS. Only valid for prediction ML Tasks.
+        :param bool reguess_level: One of the following values: TARGET_CHANGE, TARGET_REGUESS and FULL_REGUESS. Only valid for prediction ML Tasks, cannot be specified if prediction_type is also set.
         """
         obj = {}
         if prediction_type is not None:

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -1686,18 +1686,18 @@ class DSSMLTask(object):
             "POST", "/projects/%s/models/lab/%s/%s/models/%s/actions/redeployToFlow" % (self.project_key, self.analysis_id, self.mltask_id, model_id),
             body = obj)
 
-    def guess(self, prediction_type=None, target_only=None):
+    def guess(self, prediction_type=None, reguess_level=None):
         """
         Guess the feature handling and the algorithms.
         :param string prediction_type: In case of a prediction problem the prediction type can be specify. Valid values are BINARY_CLASSIFICATION, REGRESSION, MULTICLASS.
-        :param bool target_only: if True then skip ML task settings automatic detection, only the target values are remapped. Only valid for prediction ML Tasks.
+        :param bool reguess_level: One of the following values: TARGET_CHANGE, TARGET_REGUESS and FULL_REGUESS. Only valid for prediction ML Tasks.
         """
         obj = {}
         if prediction_type is not None:
             obj["predictionType"] = prediction_type
 
-        if target_only is not None:
-            obj["targetOnly"] = target_only
+        if reguess_level is not None:
+            obj["reguessLevel"] = reguess_level
 
         self.client._perform_empty(
             "PUT",


### PR DESCRIPTION
Required for the DKU App to be able to use python API to remap ML task's target without changing the rest of the settings

Linked to https://github.com/dataiku/dip/pull/10681