### PR TITLE
Add two methods to facilitate navigation from SM's objects to analysis' objects

### DIFF
--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -1,3 +1,4 @@
+from dataikuapi.dss.utils import extract_info_from_full_model_id
 from ..utils import DataikuException
 from ..utils import DataikuUTF8CSVReader
 from ..utils import DataikuStreamedHttpUTF8CSVReader
@@ -523,6 +524,23 @@ class DSSTrainedModelDetails(object):
             self.saved_model.client._perform_empty(
                 "PUT", "/projects/%s/savedmodels/%s/versions/%s/user-meta" % (self.saved_model.project_key,
                     self.saved_model.sm_id, self.saved_model_version), body = um)
+
+    def get_origin_analysis_trained_model(self):
+        """
+        Fetch details about the model in an analysis, this model has been exported from
+
+        :rtype: DSSTrainedModelDetails
+        """
+        if self.saved_model is None:
+            return self
+        else:
+            if "smOrigin" not in self.get_raw():
+                raise DataikuException("Unknow ")
+            fmi = self.get_raw()["smOrigin"]["fullModelId"]
+            _, analysis_id, mltask_id = extract_info_from_full_model_id(fmi)
+
+            origin_ml_task = DSSMLTask(self.saved_model.client, self.saved_model.project_key, analysis_id, mltask_id)
+            return origin_ml_task.get_trained_model_details(fmi)
 
 class DSSTreeNode(object):
     def __init__(self, tree, i):

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -529,7 +529,7 @@ class DSSTrainedModelDetails(object):
     def get_origin_analysis_trained_model(self):
         """
         Fetch details about the model in an analysis, this model has been exported from. Returns None if the
-        deployed trained model does not have a origin analysis trained model.
+        deployed trained model does not have an origin analysis trained model.
 
         :rtype: DSSTrainedModelDetails | None
         """

--- a/dataikuapi/dss/savedmodel.py
+++ b/dataikuapi/dss/savedmodel.py
@@ -1,3 +1,5 @@
+from dataikuapi.dss.ml import DSSMLTask
+from dataikuapi.dss.utils import extract_info_from_full_model_id
 from .ml import DSSTrainedPredictionModelDetails, DSSTrainedClusteringModelDetails
 from .metrics import ComputedMetrics
 from .ml import DSSTrainedClusteringModelDetails
@@ -15,6 +17,9 @@ class DSSSavedModel(object):
         self.project_key = project_key
         self.sm_id = sm_id
 
+    def get_definition(self):
+        return self.client._perform_json(
+            "GET", "/projects/%s/savedmodels/%s" % (self.project_key, self.sm_id))
         
     ########################################################
     # Versions
@@ -86,6 +91,18 @@ class DSSSavedModel(object):
         self.client._perform_empty(
             "POST", "/projects/%s/savedmodels/%s/actions/delete-versions" % (self.project_key, self.sm_id),
             body=body)
+
+    def get_origin_ml_task(self):
+        """
+        Fetch the last ML task that has been exported to this saved model
+
+        :rtype: DSSMLTask
+        """
+        definition = self.get_definition()
+        fmi = definition["lastExportedFrom"]
+        _, analysis_id, ml_task_id = extract_info_from_full_model_id(fmi)
+        return DSSMLTask(self.client, self.project_key, analysis_id, ml_task_id)
+
     ########################################################
     # Metrics
     ########################################################

--- a/dataikuapi/dss/savedmodel.py
+++ b/dataikuapi/dss/savedmodel.py
@@ -1,5 +1,4 @@
 from dataikuapi.dss.ml import DSSMLTask
-from .ml import DSSTrainedPredictionModelDetails, DSSTrainedClusteringModelDetails
 from .metrics import ComputedMetrics
 from .ml import DSSTrainedClusteringModelDetails
 from .ml import DSSTrainedPredictionModelDetails

--- a/dataikuapi/dss/savedmodel.py
+++ b/dataikuapi/dss/savedmodel.py
@@ -1,5 +1,4 @@
 from dataikuapi.dss.ml import DSSMLTask
-from dataikuapi.dss.utils import extract_info_from_full_model_id
 from .ml import DSSTrainedPredictionModelDetails, DSSTrainedClusteringModelDetails
 from .metrics import ComputedMetrics
 from .ml import DSSTrainedClusteringModelDetails
@@ -100,8 +99,9 @@ class DSSSavedModel(object):
         """
         definition = self.get_definition()
         fmi = definition["lastExportedFrom"]
-        _, analysis_id, ml_task_id = extract_info_from_full_model_id(fmi)
-        return DSSMLTask(self.client, self.project_key, analysis_id, ml_task_id)
+
+        origin_ml_task = DSSMLTask.from_full_model_id(self.client, fmi, project_key=self.project_key)
+        return origin_ml_task.get_trained_model_details(fmi)
 
     ########################################################
     # Metrics

--- a/dataikuapi/dss/savedmodel.py
+++ b/dataikuapi/dss/savedmodel.py
@@ -93,15 +93,16 @@ class DSSSavedModel(object):
 
     def get_origin_ml_task(self):
         """
-        Fetch the last ML task that has been exported to this saved model
+        Fetch the last ML task that has been exported to this saved model. Returns None if the saved model
+        does not have an origin ml task.
 
-        :rtype: DSSMLTask
+        :rtype: DSSMLTask | None
         """
-        definition = self.get_definition()
-        fmi = definition["lastExportedFrom"]
+        fmi = self.get_definition().get("lastExportedFrom")
+        if fmi is not None:
+            origin_ml_task = DSSMLTask.from_full_model_id(self.client, fmi, project_key=self.project_key)
+            return origin_ml_task.get_trained_model_details(fmi)
 
-        origin_ml_task = DSSMLTask.from_full_model_id(self.client, fmi, project_key=self.project_key)
-        return origin_ml_task.get_trained_model_details(fmi)
 
     ########################################################
     # Metrics

--- a/dataikuapi/dss/utils.py
+++ b/dataikuapi/dss/utils.py
@@ -1,3 +1,6 @@
+import re
+
+
 class DSSDatasetSelectionBuilder(object):
     """Builder for a "dataset selection". In DSS, a dataset selection is used to select a part of a dataset for processing.
 
@@ -258,3 +261,8 @@ class DSSTaggableObjectSettings(object):
     @custom_fields.setter
     def custom_fields(self, custom_fields):
         self._tod["customFields"] = custom_fields
+
+
+def extract_info_from_full_model_id(full_model_id):
+    match = re.search(u'([\w]+)-([\w]+)-([\w]+)-s\w+-pp\w+-m\w+', full_model_id)
+    return match.group(1), match.group(2), match.group(3)

--- a/dataikuapi/dss/utils.py
+++ b/dataikuapi/dss/utils.py
@@ -261,8 +261,3 @@ class DSSTaggableObjectSettings(object):
     @custom_fields.setter
     def custom_fields(self, custom_fields):
         self._tod["customFields"] = custom_fields
-
-
-def extract_info_from_full_model_id(full_model_id):
-    match = re.search(u'([\w]+)-([\w]+)-([\w]+)-s\w+-pp\w+-m\w+', full_model_id)
-    return match.group(1), match.group(2), match.group(3)

--- a/dataikuapi/dss/utils.py
+++ b/dataikuapi/dss/utils.py
@@ -1,6 +1,3 @@
-import re
-
-
 class DSSDatasetSelectionBuilder(object):
     """Builder for a "dataset selection". In DSS, a dataset selection is used to select a part of a dataset for processing.
 


### PR DESCRIPTION
[ch47819](https://app.clubhouse.io/dataiku/story/47819/api-to-get-source-analysis-from-saved-model-version) The goal here is to mimic the two buttons in the UI "View original analysis". 
The first on is located in the saved model page (where the list of versions are) and it redirects to the last exported ML task.
The second is located in the saved model version page and it redirects to the origin trained model of this version (either if it has been export or either if it has been retraining )

 Add two methods to facilitate navigation from saved model's objects to analysis' objects:
- for getting the origin mltask of a saved model:
```python
mltask:DSSMLTask = saved_model.get_origin_ml_task()
```
- for getting the origin trained model of a saved model version:
```python
trained_model:DSSTrainedModelDetails = saved_model_version.get_origin_analysis_trained_model()
```