### PR TITLE
Fix/ml weighting

### DIFF
--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -460,10 +460,10 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
 
     def remove_sample_weighting(self):
         """
-        Deprecated. Use unset_weighting() instead
+        Deprecated. Use set_weighting(method=\"NO_WEIGHTING\") instead
         """
-        warnings.warn("remove_sample_weighting() is deprecated, please use set_weigthing(method=\"NO_WEIGHTING\") instead", DeprecationWarning)
-        return self.set_weigthing(method="NO_WEIGHTING")
+        warnings.warn("remove_sample_weighting() is deprecated, please use set_weighting(method=\"NO_WEIGHTING\") instead", DeprecationWarning)
+        return self.set_weighting(method="NO_WEIGHTING")
 
 
 class DSSClusteringMLTaskSettings(DSSMLTaskSettings):

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -463,7 +463,8 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
         Deprecated. Use unset_weighting() instead
         """
         warnings.warn("remove_sample_weighting() is deprecated, please use set_weigthing(method=\"NO_WEIGHTING\") instead", DeprecationWarning)
-        return self.unset_weighting()
+        return self.set_weigthing(method="NO_WEIGHTING")
+
 
 class DSSClusteringMLTaskSettings(DSSMLTaskSettings):
     __doc__ = []

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -422,9 +422,9 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
         """
 
         # First, if there was a WEIGHT feature, restore it as INPUT
-        for feature_name in self.mltask_settings['preprocessing']['per_feature']:
-            if self.mltask_settings['preprocessing']['per_feature'][feature_name]['role'] == 'WEIGHT':
-                 self.mltask_settings['preprocessing']['per_feature'][feature_name]['role'] = 'INPUT'
+        for other_feature_name in self.mltask_settings['preprocessing']['per_feature']:
+            if self.mltask_settings['preprocessing']['per_feature'][other_feature_name]['role'] == 'WEIGHT':
+                self.mltask_settings['preprocessing']['per_feature'][other_feature_name]['role'] = 'INPUT'
 
         if method == "NO_WEIGHTING":
             self.mltask_settings['weight']['weightMethod'] = method


### PR DESCRIPTION
Sorry for polluting history on master...

Found and fixed 2 bugs (cc @kevanescence regarding [CH51777](https://app.clubhouse.io/dataiku/story/51777/investigate-drop-rows-tests-on-weight-test-failure)):
- The feature selected to be sample weight in `set_weighting` is not the proper one because of a local variable name conflict with `feature_name`
- Using `remove_sample_weighting` raises an exception as it calls an unimplemented method `unset_weighting`