### PR TITLE
Verify that the state does not already contain the result.

### DIFF
--- a/dataikuapi/dss/future.py
+++ b/dataikuapi/dss/future.py
@@ -72,7 +72,7 @@ class DSSFuture(object):
         """
         Wait and get the future result
         """
-        if self.state.get('hasResult', False) and 'result' in self.state:
+        if self.state.get('hasResult', False):
             return self.result_wrapper(self.state.get('result', None))
         if self.state is None or not self.state.get('hasResult', False) or self.state_is_peek:
             self.get_state()

--- a/dataikuapi/dss/future.py
+++ b/dataikuapi/dss/future.py
@@ -72,6 +72,8 @@ class DSSFuture(object):
         """
         Wait and get the future result
         """
+        if self.state.get('hasResult', False) and 'result' in self.state:
+            return self.result_wrapper(self.state.get('result', None))
         if self.state is None or not self.state.get('hasResult', False) or self.state_is_peek:
             self.get_state()
         while not self.state.get('hasResult', False):


### PR DESCRIPTION
Story details: [ch56069](https://app.clubhouse.io/dataiku/story/56069)

When the backend response is very fast to be computed, the initial response to the api call already contains the result, and does not contain a jobId.
This leads to the calls to get updates on the future to fail (no jobId)
The fix is to verify that the state does not already contain the result before an update.