### PR TITLE
Set output type to correct value when running training recipe

### DIFF
--- a/dataikuapi/dss/recipe.py
+++ b/dataikuapi/dss/recipe.py
@@ -76,18 +76,25 @@ class DSSRecipe(object):
         :return: the :class:`dataikuapi.dss.job.DSSJob` job handle corresponding to the built job
         :rtype: :class:`dataikuapi.dss.job.DSSJob`
         """
+        project = self.client.get_project(self.project_key)
+        outputs = project.get_flow().get_graph().get_successor_computables(self)
 
-        settings = self.get_settings()
-        output_refs = settings.get_flat_output_refs()
-
-        if len(output_refs) == 0:
+        if len(outputs) == 0:
             raise Exception("recipe has no outputs, can't run it")
 
-        jd = self.client.get_project(self.project_key).new_job(job_type)
-        if isinstance(settings, TrainingRecipeSettings):
-            jd.with_output(output_refs[0], object_type="SAVED_MODEL", partition=partitions)
+        first_output = outputs[0]
+
+        object_type_map = {
+            "COMPUTABLE_DATASET": "DATASET",
+            "COMPUTABLE_FOLDER": "MANAGED_FOLDER",
+            "COMPUTABLE_SAVED_MODEL": "SAVED_MODEL",
+            "COMPUTABLE_STREAMING_ENDPOINT": "STREAMING_ENDPOINT",
+        }
+        if first_output["type"] in object_type_map:
+            jd = project.new_job(job_type)
+            jd.with_output(first_output["ref"], object_type=object_type_map[first_output["type"]], partition=partitions)
         else:
-            jd.with_output(output_refs[0], partition=partitions)
+            raise Exception("recipe has unsuported output type {}, can't run it".format(first_output["type"]))
 
         if wait:
             return jd.start_and_wait()

--- a/dataikuapi/dss/recipe.py
+++ b/dataikuapi/dss/recipe.py
@@ -77,7 +77,6 @@ class DSSRecipe(object):
         :rtype: :class:`dataikuapi.dss.job.DSSJob`
         """
         project = self.client.get_project(self.project_key)
-        settings = self.get_settings()
         outputs = project.get_flow().get_graph().get_successor_computables(self)
 
         if len(outputs) == 0:
@@ -91,16 +90,11 @@ class DSSRecipe(object):
             "COMPUTABLE_SAVED_MODEL": "SAVED_MODEL",
             "COMPUTABLE_STREAMING_ENDPOINT": "STREAMING_ENDPOINT",
         }
-
-        if first_output["type"] == "COMPUTABLE_STREAMING_ENDPOINT" and not isinstance(settings, SyncRecipeSettings):
-            raise Exception(
-                "Cannot run recipe with output type STREAMING_ENDPOINT. Use a dataikuapi.dss.continuousactivity.DSSContinuousActivity instead")
-
         if first_output["type"] in object_type_map:
             jd = project.new_job(job_type)
             jd.with_output(first_output["ref"], object_type=object_type_map[first_output["type"]], partition=partitions)
         else:
-            raise Exception("Recipe has unsupported output type {}, can't run it".format(first_output["type"]))
+            raise Exception("recipe has unsuported output type {}, can't run it".format(first_output["type"]))
 
         if wait:
             return jd.start_and_wait()

--- a/dataikuapi/dss/recipe.py
+++ b/dataikuapi/dss/recipe.py
@@ -94,7 +94,7 @@ class DSSRecipe(object):
             jd = project.new_job(job_type)
             jd.with_output(first_output["ref"], object_type=object_type_map[first_output["type"]], partition=partitions)
         else:
-            raise Exception("recipe has unsuported output type {}, can't run it".format(first_output["type"]))
+            raise Exception("Recipe has unsupported output type {}, can't run it".format(first_output["type"]))
 
         if wait:
             return jd.start_and_wait()

--- a/dataikuapi/dss/recipe.py
+++ b/dataikuapi/dss/recipe.py
@@ -143,10 +143,6 @@ class DSSRecipe(object):
             return SplitRecipeSettings(self, data)
         elif type == "prepare" or type == "shaker":
             return PrepareRecipeSettings(self, data)
-        elif type == "prediction_training":
-            return TrainingRecipeSettings(self, data)
-        elif type == "clustering_training":
-            return TrainingRecipeSettings(self, data)
         #elif type == "prediction_scoring":
         #elif type == "clustering_scoring":
         elif type == "download":
@@ -1085,13 +1081,6 @@ class DownloadRecipeCreator(SingleOutputRecipeCreator):
     """
     def __init__(self, name, project):
         SingleOutputRecipeCreator.__init__(self, 'download', name, project)
-
-
-class TrainingRecipeSettings(DSSRecipeSettings):
-    """
-    Settings of a prediction or clustering training recipe. Do not create this directly, use :meth:`DSSRecipe.get_settings`
-    """
-    pass # TODO: Write helpers for training
 
 
 #####################################################

--- a/dataikuapi/dss/recipe.py
+++ b/dataikuapi/dss/recipe.py
@@ -77,9 +77,13 @@ class DSSRecipe(object):
         :rtype: :class:`dataikuapi.dss.job.DSSJob`
         """
         project = self.client.get_project(self.project_key)
-        settings = self.get_settings()
-        outputs = project.get_flow().get_graph().get_successor_computables(self)
 
+        continuous_recipes_names = set(activity.recipe_id for activity in project.list_continuous_activities())
+        if self.name in continuous_recipes_names:
+            raise Exception(
+                "Cannot run continuous recipe. Use a dataikuapi.dss.continuousactivity.DSSContinuousActivity instead")
+
+        outputs = project.get_flow().get_graph().get_successor_computables(self)
         if len(outputs) == 0:
             raise Exception("recipe has no outputs, can't run it")
 
@@ -91,11 +95,6 @@ class DSSRecipe(object):
             "COMPUTABLE_SAVED_MODEL": "SAVED_MODEL",
             "COMPUTABLE_STREAMING_ENDPOINT": "STREAMING_ENDPOINT",
         }
-
-        if first_output["type"] == "COMPUTABLE_STREAMING_ENDPOINT" and not isinstance(settings, SyncRecipeSettings):
-            raise Exception(
-                "Cannot run recipe with output type STREAMING_ENDPOINT. Use a dataikuapi.dss.continuousactivity.DSSContinuousActivity instead")
-
         if first_output["type"] in object_type_map:
             jd = project.new_job(job_type)
             jd.with_output(first_output["ref"], object_type=object_type_map[first_output["type"]], partition=partitions)

--- a/dataikuapi/dss/recipe.py
+++ b/dataikuapi/dss/recipe.py
@@ -84,7 +84,10 @@ class DSSRecipe(object):
             raise Exception("recipe has no outputs, can't run it")
 
         jd = self.client.get_project(self.project_key).new_job(job_type)
-        jd.with_output(output_refs[0], partition=partitions)
+        if isinstance(settings, TrainingRecipeSettings):
+            jd.with_output(output_refs[0], object_type="SAVED_MODEL", partition=partitions)
+        else:
+            jd.with_output(output_refs[0], partition=partitions)
 
         if wait:
             return jd.start_and_wait()
@@ -133,6 +136,10 @@ class DSSRecipe(object):
             return SplitRecipeSettings(self, data)
         elif type == "prepare" or type == "shaker":
             return PrepareRecipeSettings(self, data)
+        elif type == "prediction_training":
+            return TrainingRecipeSettings(self, data)
+        elif type == "clustering_training":
+            return TrainingRecipeSettings(self, data)
         #elif type == "prediction_scoring":
         #elif type == "clustering_scoring":
         elif type == "download":
@@ -1071,6 +1078,13 @@ class DownloadRecipeCreator(SingleOutputRecipeCreator):
     """
     def __init__(self, name, project):
         SingleOutputRecipeCreator.__init__(self, 'download', name, project)
+
+
+class TrainingRecipeSettings(DSSRecipeSettings):
+    """
+    Settings of a prediction or clustering training recipe. Do not create this directly, use :meth:`DSSRecipe.get_settings`
+    """
+    pass # TODO: Write helpers for training
 
 
 #####################################################


### PR DESCRIPTION
# Why

The `DSSRecipe.run` method fails for (prediction and clustering) training recipes, because the recipe output type is not correctly set to `"SAVED_MODEL"`, hence interpreted as a dataset.

# What
If the recipe to run is a training recipe, correctly set the output type to `"SAVED_MODEL"`

[ch54893]