### PR TITLE
Add assertions public api methods

### DIFF
--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -5,6 +5,7 @@ from ..utils import DataikuUTF8CSVReader
 from ..utils import DataikuStreamedHttpUTF8CSVReader
 import json, warnings
 import time
+import pprint
 from .metrics import ComputedMetrics
 from .utils import DSSDatasetSelectionBuilder, DSSFilterBuilder
 from .future import DSSFuture
@@ -711,6 +712,10 @@ class DSSMLAssertionParams(object):
     def __init__(self, data):
         self._internal_dict = data
 
+    def __repr__(self):
+        return u"DSSMLAssertionParams(\n    name= '{name}',\n    condition= {condition},\n    filter= {filter}\n)".format(
+            name=self.name, filter=pprint.pformat(self.filter).replace('\n', '\n            '), condition=self.condition)
+
     @staticmethod
     def from_params(name, a_filter, condition):
         """
@@ -782,6 +787,12 @@ class DSSMLAssertionCondition(object):
     """
     def __init__(self, data):
         self._internal_dict = data
+
+    def __repr__(self):
+        return u"DSSMLAssertionCondition(expected_valid_ratio = {}, expected_class= {}," \
+               u" expected_min={}, expected_max={})".format(
+            self.expected_valid_ratio, self.expected_class, self.expected_min, self.expected_max)
+
 
     @staticmethod
     def from_expected_class(expected_valid_ratio, expected_class):

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -628,6 +628,7 @@ class DSSMLDiagnostic(object):
     def get_type(self):
         """
         Returns the base Diagnostic type
+
         :rtype: str
         """
         return self._internal_dict["type"]
@@ -635,6 +636,7 @@ class DSSMLDiagnostic(object):
     def get_type_pretty(self):
         """
         Returns the Diagnostic type as displayed in the UI
+
         :rtype: str
         """
         return self._internal_dict["displayableType"]
@@ -642,6 +644,7 @@ class DSSMLDiagnostic(object):
     def get_message(self):
         """
         Returns the message as displayed in the UI
+
         :rtype: str
         """
         return self._internal_dict["message"]
@@ -664,6 +667,7 @@ class DSSMLAssertionsParams(object):
     def get_raw(self):
         """
         Gets the raw dictionary of the assertions parameters
+
         :rtype: dict
         """
         return self._internal_dict
@@ -739,6 +743,7 @@ class DSSMLAssertionParams(object):
     def get_raw(self):
         """
         Gets the raw dictionary of the assertion parameters
+
         :rtype: dict
         """
         return self._internal_dict
@@ -747,6 +752,7 @@ class DSSMLAssertionParams(object):
     def name(self):
         """
         Returns the assertion name
+
         :rtype: str
         """
         return self._internal_dict["name"]
@@ -759,6 +765,7 @@ class DSSMLAssertionParams(object):
     def filter(self):
         """
         Returns the assertion filter
+
         :rtype: dict
         """
         return self._internal_dict["filter"]
@@ -771,6 +778,7 @@ class DSSMLAssertionParams(object):
     def condition(self):
         """
         Returns the assertion condition
+
         :rtype: :class:`DSSMLAssertionCondition`
         """
         return DSSMLAssertionCondition(self._internal_dict["assertionCondition"])
@@ -834,6 +842,7 @@ class DSSMLAssertionCondition(object):
     def get_raw(self):
         """
         Gets the raw dictionary of the condition
+
         :rtype: dict
         """
         return self._internal_dict
@@ -843,6 +852,7 @@ class DSSMLAssertionCondition(object):
         """
         Returns the expected class or None if it is not defined. Assertion passes if the expected_valid_ratio
         of rows predicted as expected_class is attained.
+
         :rtype: str
         """
         if "expectedClass" in self._internal_dict:
@@ -859,6 +869,7 @@ class DSSMLAssertionCondition(object):
         """
         Returns the ratio of valid rows to exceed for the assertion to pass. A row is considered valid if the prediction
         is equal to the expected class for classification or in the expected range for regression.
+
         :rtype: str
         """
         return self._internal_dict["expectedValidRatio"]
@@ -872,6 +883,7 @@ class DSSMLAssertionCondition(object):
         """
         Returns the min (included) of the expected range or None if it is not defined.
         Assertion passes if the expected_valid_ratio of rows predicted between expected_min and expected_max (included) is attained.
+
         :rtype: float
         """
         if "expectedMinValue" in self._internal_dict:
@@ -888,6 +900,7 @@ class DSSMLAssertionCondition(object):
         """
         Returns the max (included) of the expected range or None if it is not defined.
         Assertion passes if the ratio of rows predicted between expected_min and expected_max (included) is attained.
+
         :rtype: float
         """
         if "expectedMaxValue" in self._internal_dict:
@@ -911,6 +924,7 @@ class DSSMLAssertionsMetrics(object):
     def get_raw(self):
         """
         Gets the raw dictionary of the assertions metrics
+
         :rtype: dict
         """
         return self._internal_dict
@@ -934,6 +948,7 @@ class DSSMLAssertionsMetrics(object):
     def passing_assertions_ratio(self):
         """
         Returns the ratio of passing assertions
+
         :rtype: float
         """
         return self._internal_dict['passingAssertionsRatio']
@@ -954,6 +969,7 @@ class DSSMLAssertionMetric(object):
     def get_raw(self):
         """
         Gets the raw dictionary of metrics of one assertion
+
         :rtype: dict
         """
         return self._internal_dict
@@ -962,6 +978,7 @@ class DSSMLAssertionMetric(object):
     def name(self):
         """
         Returns the assertion name
+
         :rtype: str
         """
         return self._internal_dict["name"]
@@ -970,6 +987,7 @@ class DSSMLAssertionMetric(object):
     def result(self):
         """
         Returns whether the assertion passes
+
         :rtype: bool
         """
         return self._internal_dict["result"]
@@ -979,6 +997,7 @@ class DSSMLAssertionMetric(object):
         """
         Returns the ratio of rows in the assertion population with prediction equals to the expected class
         for classification or in the expected range for regression
+
         :rtype: float
         """
         return self._internal_dict["validRatio"]
@@ -987,6 +1006,7 @@ class DSSMLAssertionMetric(object):
     def nb_matching_rows(self):
         """
         Returns the number of rows matching filter
+
         :rtype: int
         """
         return self._internal_dict["nbMatchingRows"]
@@ -995,6 +1015,7 @@ class DSSMLAssertionMetric(object):
     def nb_dropped_rows(self):
         """
         Returns the number of rows dropped by the model's preprocessing
+
         :rtype: int
         """
         return self._internal_dict["nbDroppedRows"]
@@ -1161,6 +1182,7 @@ class DSSTrainedPredictionModelDetails(DSSTrainedModelDetails):
     def get_assertions_metrics(self):
         """
         Retrieves assertions metrics computed for this trained model
+
         :returns: an object representing assertion metrics
         :rtype: :class:`DSSMLAssertionsMetrics`
         """
@@ -1858,6 +1880,7 @@ class DSSTrainedClusteringModelDetails(DSSTrainedModelDetails):
     def get_performance_metrics(self):
         """
         Returns all performance metrics for this clustering model.
+
         :returns: a dict of performance metrics values
         :rtype: dict
         """
@@ -1890,6 +1913,7 @@ class DSSTrainedClusteringModelDetails(DSSTrainedModelDetails):
     def get_actual_modeling_params(self):
         """
         Gets the actual / resolved parameters that were used to train this model.
+
         :return: A dictionary, which contains at least a "resolved" key
         :rtype: dict
         """

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -731,7 +731,8 @@ class DSSMLAssertionParams(object):
         Creates assertion parameters from name, filter and condition
 
         :param str name: Name of the assertion
-        :param object a_filter: A dict representing the filter to select assertion population
+        :param dict a_filter: A dict representing the filter to select assertion population. You can use
+        a :class:`~dataikuapi.dss.utils.DSSFilterBuilder` to build the settings of the filter
         :param object condition: A :class:`DSSMLAssertionCondition` for the assertion to be successful
 
         :rtype: :class:`DSSMLAssertionParams`

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -5,7 +5,6 @@ from ..utils import DataikuUTF8CSVReader
 from ..utils import DataikuStreamedHttpUTF8CSVReader
 import json, warnings
 import time
-import pprint
 from .metrics import ComputedMetrics
 from .utils import DSSDatasetSelectionBuilder, DSSFilterBuilder
 from .future import DSSFuture
@@ -720,8 +719,8 @@ class DSSMLAssertionParams(object):
         self._internal_dict = data
 
     def __repr__(self):
-        return u"DSSMLAssertionParams(\n    name= '{name}',\n    condition= {condition},\n    filter= {filter}\n)".format(
-            name=self.name, filter=pprint.pformat(self.filter).replace('\n', '\n            '), condition=self.condition)
+        return u"DSSMLAssertionParams(name= '{name}', condition= {condition}, filter= {filter})".format(
+            name=self.name, filter=self.filter, condition=self.condition)
 
     @staticmethod
     def from_params(name, a_filter, condition):
@@ -963,8 +962,8 @@ class DSSMLAssertionMetric(object):
         self._internal_dict = data
 
     def __repr__(self):
-        return u"DSSMLAssertionParams(\n    name='{}',\n    result={},\n    valid_ratio={},\n    nb_matching_rows={}," \
-               u"\n    nb_dropped_rows={}\n)".format(self.name, self.result, self.valid_ratio, self.nb_matching_rows,
+        return u"DSSMLAssertionParams(name='{}', result={}, valid_ratio={}, nb_matching_rows={}," \
+               u" nb_dropped_rows={})".format(self.name, self.result, self.valid_ratio, self.nb_matching_rows,
                                                  self.nb_dropped_rows)
     def get_raw(self):
         """

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -928,19 +928,19 @@ class DSSMLAssertionsMetrics(object):
         """
         return self._internal_dict
 
-    def get_metric(self, assertion_name):
+    def get_metrics(self, assertion_name):
         """
-        Retrieves the metric computed for this trained model for the assertion with the provided name (or None if no
+        Retrieves the metrics computed for this trained model for the assertion with the provided name (or None if no
         assertion with that name exists)
 
         :param str assertion_name: Name of the assertion
 
         :returns: an object representing assertion metrics or None if no assertion with that name exists
-        :rtype: :class:`DSSMLAssertionMetric`
+        :rtype: :class:`DSSMLAssertionMetrics`
         """
-        for assertion_metric_dict in self._internal_dict["perAssertion"]:
-            if assertion_name == assertion_metric_dict["name"]:
-                return DSSMLAssertionMetric(assertion_metric_dict)
+        for assertion_metrics_dict in self._internal_dict["perAssertion"]:
+            if assertion_name == assertion_metrics_dict["name"]:
+                return DSSMLAssertionMetrics(assertion_metrics_dict)
         return None
 
     @property
@@ -953,10 +953,10 @@ class DSSMLAssertionsMetrics(object):
         return self._internal_dict['passingAssertionsRatio']
 
 
-class DSSMLAssertionMetric(object):
+class DSSMLAssertionMetrics(object):
     """
     Object that represents the result of an assertion on a trained model
-    Do not create this object directly, use :meth:`DSSMLAssertionMetrics.get_metric(self, assertion_name)` instead
+    Do not create this object directly, use :meth:`DSSMLAssertionMetrics.get_metrics(self, assertion_name)` instead
     """
     def __init__(self, data):
         self._internal_dict = data

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -436,7 +436,7 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
         """
         Retrieves the assertions parameters for this ml task
 
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsParams`
+        :rtype: :class:`DSSMLAssertionsParams`
         """
         return DSSMLAssertionsParams(self.mltask_settings["assertionsParams"])
 
@@ -670,10 +670,10 @@ class DSSMLAssertionsParams(object):
 
     def get_assertion(self, assertion_name):
         """
-        Gets a :class:`dataikuapi.dss.ml.DSSMLAssertionParams` representing the parameters of the assertion with the
+        Gets a :class:`DSSMLAssertionParams` representing the parameters of the assertion with the
         provided name (or None if no assertion has that name)
         :param str assertion_name: Name of the assertion
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionParams` or None if no assertion has that name
+        :rtype: :class:`DSSMLAssertionParams` or None if no assertion has that name
         """
         for assertion_dict in self._internal_dict["assertions"]:
             if assertion_dict["name"] == assertion_name:
@@ -683,7 +683,7 @@ class DSSMLAssertionsParams(object):
     def add_assertion(self, assertion_params):
         """
         Adds parameters of an assertion to the assertions parameters of the ml task.
-        :param object  assertion_params: A :class:`~dataikuapi.dss.utils.DSSMLAssertionParams` representing parameters of the assertion
+        :param object  assertion_params: A :class:`DSSMLAssertionParams` representing parameters of the assertion
         """
         if not isinstance(assertion_params, DSSMLAssertionParams):
             raise ValueError('Wrong type for assertion parameters: {}'.format(type(assertion_params)))
@@ -723,9 +723,9 @@ class DSSMLAssertionParams(object):
 
         :param str name: Name of the assertion
         :param object a_filter: A dict representing the filter to select assertion population
-        :param object condition: A :class:`~dataikuapi.dss.ml.DSSMLAssertionCondition` for the assertion to be successful
+        :param object condition: A :class:`DSSMLAssertionCondition` for the assertion to be successful
 
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionParams`
+        :rtype: :class:`DSSMLAssertionParams`
         """
         assertion_params = DSSMLAssertionParams({})
         assertion_params.name = name
@@ -768,7 +768,7 @@ class DSSMLAssertionParams(object):
     def condition(self):
         """
         Returns the assertion condition
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionCondition`
+        :rtype: :class:`DSSMLAssertionCondition`
         """
         return DSSMLAssertionCondition(self._internal_dict["assertionCondition"])
 
@@ -802,7 +802,7 @@ class DSSMLAssertionCondition(object):
         :param float expected_valid_ratio: Assertion passes if this ratio of rows predicted as expected_class is attained
         :param str expected_class: Assertion passes if the ratio of rows predicted as expected_class is attained
 
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionCondition`
+        :rtype: :class:`DSSMLAssertionCondition`
         """
         assertion_condition = DSSMLAssertionCondition({})
         assertion_condition.expected_valid_ratio = expected_valid_ratio
@@ -820,7 +820,7 @@ class DSSMLAssertionCondition(object):
         :param float expected_min: Min value of the expected range
         :param float expected_max: Max value of the expected range
 
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionCondition`
+        :rtype: :class:`DSSMLAssertionCondition`
         """
         assertion_condition = DSSMLAssertionCondition({})
         assertion_condition.expected_valid_ratio = expected_valid_ratio
@@ -920,7 +920,7 @@ class DSSMLAssertionsMetrics(object):
         :param str assertion_name: Name of the assertion
 
         :returns: an object representing assertion metrics or None if no assertion with that name exists
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionMetric`
+        :rtype: :class:`DSSMLAssertionMetric`
         """
         for assertion_metric_dict in self._internal_dict["perAssertion"]:
             if assertion_name == assertion_metric_dict["name"]:
@@ -1159,7 +1159,7 @@ class DSSTrainedPredictionModelDetails(DSSTrainedModelDetails):
         """
         Retrieves assertions metrics computed for this trained model
         :returns: an object representing assertion metrics
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsMetrics`
+        :rtype: :class:`DSSMLAssertionsMetrics`
         """
         return DSSMLAssertionsMetrics(self.snippet["assertionsMetrics"])
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -437,7 +437,7 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
 
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsParams`
         """
-        return DSSMLAssertionsParams(self.mltask_settings["assertionParams"])
+        return DSSMLAssertionsParams(self.mltask_settings["assertionsParams"])
 
     def split_ordered_by(self, feature_name, ascending=True):
         """
@@ -847,11 +847,11 @@ class DSSMLAssertionCondition(object):
         is equal to the expected class for classification or in the expected range for regression.
         :rtype: str
         """
-        return self._internal_dict["successRatio"]
+        return self._internal_dict["expectedValidRatio"]
 
     @expected_valid_ratio.setter
     def expected_valid_ratio(self, expected_valid_ratio):
-        self._internal_dict["successRatio"] = expected_valid_ratio
+        self._internal_dict["expectedValidRatio"] = expected_valid_ratio
 
     @property
     def expected_min(self):
@@ -917,12 +917,12 @@ class DSSMLAssertionsMetrics(object):
         return None
 
     @property
-    def positive_assertion_ratio(self):
+    def passing_assertions_ratio(self):
         """
         Returns the ratio of passing assertions
         :rtype: float
         """
-        return self._internal_dict['positiveAssertionsRatio']
+        return self._internal_dict['passingAssertionsRatio']
 
 
 class DSSMLAssertionMetric(object):

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -696,7 +696,6 @@ class DSSMLAssertionsParams(object):
         """
         if not isinstance(assertion_params, DSSMLAssertionParams):
             raise ValueError('Wrong type for assertion parameters: {}'.format(type(assertion_params)))
-        self.check_assertion_names_are_uniq(self._internal_dict["assertions"] + [assertion_params._internal_dict])
 
         self._internal_dict["assertions"].append(assertion_params._internal_dict)
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -672,7 +672,7 @@ class DSSMLAssertionsParams(object):
         Gets a :class:`dataikuapi.dss.ml.DSSMLAssertionParams` representing the parameters of the assertion with the
         provided name (or None if no assertion has that name)
         :param str assertion_name: Name of the assertion
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionParams` or None
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionParams` or None if no assertion has that name
         """
         for assertion_dict in self._internal_dict["assertions"]:
             if assertion_dict["name"] == assertion_name:
@@ -682,7 +682,6 @@ class DSSMLAssertionsParams(object):
     def add_assertion(self, assertion_params):
         """
         Adds parameters of an assertion to the assertions parameters of the ml task.
-        Raises a ValueError if an assertion with the same name already exists
         :param object  assertion_params: A :class:`~dataikuapi.dss.utils.DSSMLAssertionParams` representing parameters of the assertion
         """
         if not isinstance(assertion_params, DSSMLAssertionParams):
@@ -692,7 +691,7 @@ class DSSMLAssertionsParams(object):
 
     def delete_assertion(self, assertion_name):
         """
-        Deletes the assertion parameters of the assertion with the provided name from the `dataikuapi.dss.ml.DSSMLAssertionsParams`
+        Deletes the assertion parameters of the assertion with the provided name from the assertions parameters of the ml task.
         Raises a ValueError if no assertion with the provided name was found
         :param str assertion_name: Name of the assertion
         """
@@ -845,7 +844,7 @@ class DSSMLAssertionCondition(object):
     def expected_valid_ratio(self):
         """
         Returns the ratio of valid rows to exceed for the assertion to pass. A row is considered valid if the prediction
-        is equal to the `expected_class` for classification or in the expected range for regression
+        is equal to the expected class for classification or in the expected range for regression
         :rtype: str
         """
         return self._internal_dict["successRatio"]
@@ -952,7 +951,7 @@ class DSSMLAssertionMetric(object):
     @property
     def result(self):
         """
-        Returns whether the assertion pass
+        Returns whether the assertion passes
         :rtype: bool
         """
         return self._internal_dict["result"]

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -944,6 +944,10 @@ class DSSMLAssertionMetric(object):
     def __init__(self, data):
         self._internal_dict = data
 
+    def __repr__(self):
+        return u"DSSMLAssertionParams(\n    name='{}',\n    result={},\n    valid_ratio={},\n    nb_matching_rows={}," \
+               u"\n    nb_dropped_rows={}\n)".format(self.name, self.result, self.valid_ratio, self.nb_matching_rows,
+                                                 self.nb_dropped_rows)
     def get_raw(self):
         """
         Gets the raw dictionary of metrics of one assertion

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -689,9 +689,9 @@ class DSSMLAssertionsParams(object):
 
     def get_assertions_names(self):
         """
-        Gets the list of all assertion's names
+        Gets the list of all assertions' names
 
-        :return: A list of all assertion's names
+        :return: A list of all assertions' names
         :rtype: list
         """
         return [assertion_dict["name"] for assertion_dict in self._internal_dict["assertions"]]
@@ -725,7 +725,7 @@ class DSSMLAssertionParams(object):
     """
     Object that represents parameters for one assertion
     Do not create this object directly, use :meth:`DSSMLAssertionsParams.get_assertion(assertion_name)` or
-    `from_parts(name, a_filter, condition)` instead
+    `from_params(name, a_filter, condition)` instead
     """
     def __init__(self, data):
         self._internal_dict = data

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -706,7 +706,7 @@ class DSSMLAssertionsParams(object):
 class DSSMLAssertionParams(object):
     """
     Object that represents parameters for one assertion
-    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionsParams.get_assertion(assertion_name)` or
+    Do not create this object directly, use :meth:`DSSMLAssertionsParams.get_assertion(assertion_name)` or
     `from_parts(name, a_filter, condition)` instead
     """
     def __init__(self, data):
@@ -782,8 +782,8 @@ class DSSMLAssertionParams(object):
 class DSSMLAssertionCondition(object):
     """
     Object that represents an assertion condition
-    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionParams.condition`, :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.from_expected_class(expected_valid_ratio, expected_class)`
-    or :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.from_expected_range(expected_valid_ratio, expected_min, expected_max)` instead
+    Do not create this object directly, use :meth:`DSSMLAssertionParams.condition`, :meth:`DSSMLAssertionCondition.from_expected_class(expected_valid_ratio, expected_class)`
+    or :meth:`DSSMLAssertionCondition.from_expected_range(expected_valid_ratio, expected_min, expected_max)` instead
     """
     def __init__(self, data):
         self._internal_dict = data
@@ -900,7 +900,7 @@ class DSSMLAssertionCondition(object):
 class DSSMLAssertionsMetrics(object):
     """
     Object that represents the per assertion metrics for all assertions on a trained model
-    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSTrainedPredictionModelDetails.get_assertions_metrics()` instead
+    Do not create this object directly, use :meth:`DSSTrainedPredictionModelDetails.get_assertions_metrics()` instead
     """
     def __init__(self, data):
         self._internal_dict = data
@@ -939,7 +939,7 @@ class DSSMLAssertionsMetrics(object):
 class DSSMLAssertionMetric(object):
     """
     Object that represents the result of an assertion on a trained model
-    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionMetrics.get_metric(self, assertion_name)` instead
+    Do not create this object directly, use :meth:`DSSMLAssertionMetrics.get_metric(self, assertion_name)` instead
     """
     def __init__(self, data):
         self._internal_dict = data

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -725,7 +725,7 @@ class DSSMLAssertionParams(object):
     """
     Object that represents parameters for one assertion
     Do not create this object directly, use :meth:`DSSMLAssertionsParams.get_assertion` or
-    `from_params` instead
+    :meth:`from_params` instead
     """
     def __init__(self, data):
         self._internal_dict = data

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -916,6 +916,7 @@ class DSSMLAssertionsMetrics(object):
         Retrieves the metric computed for this trained model for the assertion with the provided name (or None)
 
         :param str assertion_name: Name of the assertion
+
         :returns: an object representing assertion metrics
         :rtype: `dataikuapi.dss.ml.DSSMLAssertionMetric`
         """

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -798,8 +798,8 @@ class DSSMLAssertionCondition(object):
         """
         Creates an assertion condition from the expected valid ratio and class
 
-        :param float expected_valid_ratio: Ratio of valid rows needed for the assertion to pass
-        :param str expected_class: Class on which the `expected_valid_ratio` will be calculated
+        :param float expected_valid_ratio: Assertion passes if this ratio of rows predicted as expected_class is attained
+        :param str expected_class: Assertion passes if the ratio of rows predicted as expected_class is attained
 
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionCondition`
         """
@@ -811,7 +811,7 @@ class DSSMLAssertionCondition(object):
     @staticmethod
     def from_expected_range(expected_valid_ratio, expected_min, expected_max):
         """
-        Creates an assertion condition from an expected valid ratio and an expected range. The expected range is the
+        Creates an assertion condition from expected valid ratio and range. The expected range is the
         interval between expected_min and expected_max where the predictions and therefore the rows will be considered
         valid.
 
@@ -837,7 +837,8 @@ class DSSMLAssertionCondition(object):
     @property
     def expected_class(self):
         """
-        Returns the expected class on which the valid ratio will be calculated or None if it is not defined
+        Returns the expected class or None if it is not defined. Assertion passes if the ratio of rows predicted
+        as expected_class is attained
         :rtype: str
         """
         if "expectedClass" in self._internal_dict:
@@ -852,7 +853,8 @@ class DSSMLAssertionCondition(object):
     @property
     def expected_valid_ratio(self):
         """
-        Returns the ratio of valid rows to exceed for the assertion to pass
+        Returns the ratio of valid rows to exceed for the assertion to pass. A row is considered valid if the prediction
+        is equal to the `expected_class` for classification or in the expected range for regresion
         :rtype: str
         """
         return self._internal_dict["successRatio"]
@@ -864,7 +866,8 @@ class DSSMLAssertionCondition(object):
     @property
     def expected_min(self):
         """
-        Returns the min (included) of the expected range or None if it is not defined
+        Returns the min (included) of the expected range or None if it is not defined. Assertion passes if the ratio of rows predicted
+        between expected_min and expected_max is attained
         :rtype: float
         """
         if "expectedMinValue" in self._internal_dict:
@@ -879,7 +882,8 @@ class DSSMLAssertionCondition(object):
     @property
     def expected_max(self):
         """
-        Returns the max (included) of the expected range
+        Returns the max (included) of the expected range or None if it is not defined. Assertion passes if the ratio of rows predicted
+        between expected_min and expected_max is attained
         :rtype: float
         """
         if "expectedMaxValue" in self._internal_dict:

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -825,7 +825,7 @@ class DSSMLAssertionCondition(object):
         """
         Creates an assertion condition from an expected valid ratio and an expected range
 
-        :param float expected_valid_ratio: Ratio of valid rows to exceed for the assertion to pass
+        :param float expected_valid_ratio: Assertion passes if this ratio of rows predicted between expected_min and expected_max is attained
         :param tuple(float,float) expected_range: Range of values (min, max) where the prediction will be considered as
         valid for the `expected_valid_ratio`
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -781,7 +781,7 @@ class DSSMLAssertionParams(object):
     @condition.setter
     def condition(self, condition):
         if not isinstance(condition, DSSMLAssertionCondition):
-            raise ValueError('Wrong type for assertion condition: {}.format(type(condition))')
+            raise ValueError('Wrong type for assertion condition: {}'.format(type(condition)))
         self._internal_dict["assertionCondition"] = condition._internal_dict
 
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -687,6 +687,15 @@ class DSSMLAssertionsParams(object):
                 return DSSMLAssertionParams(assertion_dict)
         return None
 
+    def get_assertions_names(self):
+        """
+        Gets the list of all assertion's names
+
+        :return: A list of all assertion's names
+        :rtype: list
+        """
+        return [assertion_dict["name"] for assertion_dict in self._internal_dict["assertions"]]
+
     def add_assertion(self, assertion_params):
         """
         Adds parameters of an assertion to the assertions parameters of the ml task.

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -774,8 +774,8 @@ class DSSMLAssertionParams(object):
         return self._internal_dict["filter"]
 
     @filter.setter
-    def filter(self, filter):
-        self._internal_dict["filter"] = filter
+    def filter(self, a_filter):
+        self._internal_dict["filter"] = a_filter
 
     @property
     def condition(self):
@@ -902,7 +902,7 @@ class DSSMLAssertionCondition(object):
     def expected_max(self):
         """
         Returns the max (included) of the expected range or None if it is not defined.
-        Assertion passes if the ratio of rows predicted between expected_min and expected_max (included) is attained.
+        Assertion passes if the expected_valid_ratio of rows predicted between expected_min and expected_max (included) is attained.
 
         :rtype: float
         """
@@ -1021,7 +1021,7 @@ class DSSMLAssertionMetrics(object):
     @property
     def nb_dropped_rows(self):
         """
-        Returns the number of rows dropped by the model's preprocessing
+        Returns the number of rows matching filter and dropped by the model's preprocessing
 
         :rtype: int
         """

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -717,7 +717,7 @@ class DSSMLAssertionParams(object):
         Creates assertion parameters from name, filter and condition
 
         :param str name: Name of the assertion
-        :param object a_filter: A :class:`~dataikuapi.dss.utils.DSSFilter`  to select assertion population
+        :param object a_filter: A :class:`~dataikuapi.dss.utils.DSSFilter` to select assertion population
         :param object condition: A :class:`~dataikuapi.dss.ml.DSSMLAssertionCondition` for the assertion to be successful
 
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionParams`
@@ -805,7 +805,7 @@ class DSSMLAssertionCondition(object):
         The expected range is the interval between expected_min and expected_max (included)
         for the predictions in which the rows will be considered valid.
 
-        :param float expected_valid_ratio: Assertion passes if this ratio of rows predicted between expected_min and expected_max is attained
+        :param float expected_valid_ratio: Assertion passes if this ratio of rows predicted between expected_min and expected_max (included) is attained
         :param float expected_min: Min value of the expected range
         :param float expected_max: Max value of the expected range
 
@@ -857,7 +857,7 @@ class DSSMLAssertionCondition(object):
     def expected_min(self):
         """
         Returns the min (included) of the expected range or None if it is not defined.
-        Assertion passes if the ratio of rows predicted between expected_min and expected_max is attained.
+        Assertion passes if the expected_valid_ratio of rows predicted between expected_min and expected_max (included) is attained.
         :rtype: float
         """
         if "expectedMinValue" in self._internal_dict:
@@ -873,7 +873,7 @@ class DSSMLAssertionCondition(object):
     def expected_max(self):
         """
         Returns the max (included) of the expected range or None if it is not defined.
-        Assertion passes if the ratio of rows predicted between expected_min and expected_max is attained.
+        Assertion passes if the ratio of rows predicted between expected_min and expected_max (included) is attained.
         :rtype: float
         """
         if "expectedMaxValue" in self._internal_dict:

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -672,6 +672,7 @@ class DSSMLAssertionsParams(object):
         """
         Gets a :class:`DSSMLAssertionParams` representing the parameters of the assertion with the
         provided name (or None if no assertion has that name)
+
         :param str assertion_name: Name of the assertion
         :rtype: :class:`DSSMLAssertionParams` or None if no assertion has that name
         """
@@ -683,6 +684,7 @@ class DSSMLAssertionsParams(object):
     def add_assertion(self, assertion_params):
         """
         Adds parameters of an assertion to the assertions parameters of the ml task.
+
         :param object  assertion_params: A :class:`DSSMLAssertionParams` representing parameters of the assertion
         """
         if not isinstance(assertion_params, DSSMLAssertionParams):
@@ -694,6 +696,7 @@ class DSSMLAssertionsParams(object):
         """
         Deletes the assertion parameters of the assertion with the provided name from the assertions parameters of the ml task.
         Raises a ValueError if no assertion with the provided name was found
+
         :param str assertion_name: Name of the assertion
         """
         for idx, assertion_dict in enumerate(self._internal_dict["assertions"]):

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -802,9 +802,9 @@ class DSSMLAssertionCondition(object):
     @staticmethod
     def from_expected_range(expected_valid_ratio, expected_min, expected_max):
         """
-        Creates an assertion condition from expected valid ratio and range. The expected range is the
-        interval between expected_min and expected_max where the predictions and therefore the rows will be considered
-        valid.
+        Creates an assertion condition from expected valid ratio and range.
+        The expected range is the interval between expected_min and expected_max (included)
+        for the predictions in which the rows will be considered valid.
 
         :param float expected_valid_ratio: Assertion passes if this ratio of rows predicted between expected_min and expected_max is attained
         :param float expected_min: Min value of the expected range
@@ -828,8 +828,8 @@ class DSSMLAssertionCondition(object):
     @property
     def expected_class(self):
         """
-        Returns the expected class or None if it is not defined. Assertion passes if the ratio of rows predicted
-        as expected_class is attained
+        Returns the expected class or None if it is not defined. Assertion passes if the expected_valid_ratio
+        of rows predicted as expected_class is attained.
         :rtype: str
         """
         if "expectedClass" in self._internal_dict:
@@ -845,7 +845,7 @@ class DSSMLAssertionCondition(object):
     def expected_valid_ratio(self):
         """
         Returns the ratio of valid rows to exceed for the assertion to pass. A row is considered valid if the prediction
-        is equal to the `expected_class` for classification or in the expected range for regresion
+        is equal to the `expected_class` for classification or in the expected range for regression
         :rtype: str
         """
         return self._internal_dict["successRatio"]
@@ -857,8 +857,8 @@ class DSSMLAssertionCondition(object):
     @property
     def expected_min(self):
         """
-        Returns the min (included) of the expected range or None if it is not defined. Assertion passes if the ratio of rows predicted
-        between expected_min and expected_max is attained
+        Returns the min (included) of the expected range or None if it is not defined.
+        Assertion passes if the ratio of rows predicted between expected_min and expected_max is attained.
         :rtype: float
         """
         if "expectedMinValue" in self._internal_dict:
@@ -873,8 +873,8 @@ class DSSMLAssertionCondition(object):
     @property
     def expected_max(self):
         """
-        Returns the max (included) of the expected range or None if it is not defined. Assertion passes if the ratio of rows predicted
-        between expected_min and expected_max is attained
+        Returns the max (included) of the expected range or None if it is not defined.
+        Assertion passes if the ratio of rows predicted between expected_min and expected_max is attained.
         :rtype: float
         """
         if "expectedMaxValue" in self._internal_dict:

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -673,7 +673,7 @@ class DSSMLAssertionsParams(object):
             if 'name' not in assertion_dict:
                 raise ValueError('No name provided for assertion')
             if assertion_dict['name'] in _:
-                raise ValueError('Assertion names should be uniq. {} is multiple times in the data'.format(
+                raise ValueError('Assertion names must be unique, but got multiple instances of: {}'.format(
                     assertion_dict['name']))
             _[assertion_dict['name']] = True
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -657,7 +657,7 @@ class DSSMLDiagnostic(object):
 class DSSMLAssertionsParams(object):
     """
     Object that represents parameters for all assertions of a ml task
-    Do not create this object directly, use :meth:`DSSPredictionMLTaskSettings.get_assertions_params()` instead
+    Do not create this object directly, use :meth:`DSSPredictionMLTaskSettings.get_assertions_params` instead
     """
 
     def __init__(self, data):
@@ -724,8 +724,8 @@ class DSSMLAssertionsParams(object):
 class DSSMLAssertionParams(object):
     """
     Object that represents parameters for one assertion
-    Do not create this object directly, use :meth:`DSSMLAssertionsParams.get_assertion(assertion_name)` or
-    `from_params(name, a_filter, condition)` instead
+    Do not create this object directly, use :meth:`DSSMLAssertionsParams.get_assertion` or
+    `from_params` instead
     """
     def __init__(self, data):
         self._internal_dict = data
@@ -804,15 +804,14 @@ class DSSMLAssertionParams(object):
 class DSSMLAssertionCondition(object):
     """
     Object that represents an assertion condition
-    Do not create this object directly, use :meth:`DSSMLAssertionParams.condition`, :meth:`DSSMLAssertionCondition.from_expected_class(expected_valid_ratio, expected_class)`
-    or :meth:`DSSMLAssertionCondition.from_expected_range(expected_valid_ratio, expected_min, expected_max)` instead
+    Do not create this object directly, use :meth:`DSSMLAssertionParams.condition`,
+    :meth:`DSSMLAssertionCondition.from_expected_class` or :meth:`DSSMLAssertionCondition.from_expected_range` instead
     """
     def __init__(self, data):
         self._internal_dict = data
 
     def __repr__(self):
         return u"{}({})".format(self.__class__.__name__, self.get_raw())
-
 
     @staticmethod
     def from_expected_class(expected_valid_ratio, expected_class):
@@ -925,7 +924,7 @@ class DSSMLAssertionCondition(object):
 class DSSMLAssertionsMetrics(object):
     """
     Object that represents the assertions metrics for all assertions on a trained model
-    Do not create this object directly, use :meth:`DSSTrainedPredictionModelDetails.get_assertions_metrics()` instead
+    Do not create this object directly, use :meth:`DSSTrainedPredictionModelDetails.get_assertions_metrics` instead
     """
     def __init__(self, data):
         self._internal_dict = data
@@ -969,7 +968,7 @@ class DSSMLAssertionsMetrics(object):
 class DSSMLAssertionMetrics(object):
     """
     Object that represents the result of an assertion on a trained model
-    Do not create this object directly, use :meth:`DSSMLAssertionMetrics.get_metrics(self, assertion_name)` instead
+    Do not create this object directly, use :meth:`DSSMLAssertionMetrics.get_metrics` instead
     """
     def __init__(self, data):
         self._internal_dict = data

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -707,7 +707,7 @@ class DSSMLAssertionsParams(object):
         :param object  assertion_params: A :class:`~dataikuapi.dss.utils.DSSMLAssertionParams` representing parameters of the assertion
         """
         if not isinstance(assertion_params, DSSMLAssertionParams):
-            raise ValueError('Assertion params should be of type: {} not {}'.format(DSSMLAssertionParams.__name__, type(assertion_params)))
+            raise ValueError('Wrong type for assertion params: {}'.format(type(assertion_params)))
         self.check_assertion_names_are_uniq(self._internal_dict["assertions"] + [assertion_params._internal_dict])
         self._internal_dict["assertions"].append(assertion_params._internal_dict)
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -434,7 +434,7 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
     @property
     def assertions_params(self):
         """
-        Retrieves the assertions params for this ml task
+        Retrieves the assertions parameters for this ml task
 
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsParams`
         """
@@ -442,7 +442,7 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
 
     def get_assertions_params(self):
         """
-        Retrieves the assertions params for this ml task
+        Retrieves the assertions parameters for this ml task
 
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsParams`
         """
@@ -666,31 +666,19 @@ class DSSMLAssertionsParams(object):
     Do not create this object directly, use :meth:`DSSPredictionMLTaskSettings.get_assertions_params()` instead
     """
 
-    @staticmethod
-    def check_assertion_names_are_uniq(assertion_params_list):
-        _ = {}
-        for assertion_dict in assertion_params_list:
-            if 'name' not in assertion_dict:
-                raise ValueError('No name provided for assertion')
-            if assertion_dict['name'] in _:
-                raise ValueError('Assertion names must be unique, but got multiple instances of: {}'.format(
-                    assertion_dict['name']))
-            _[assertion_dict['name']] = True
-
     def __init__(self, data):
         self._internal_dict = data
-        self.check_assertion_names_are_uniq(data["assertions"])
 
     def get_raw(self):
         """
-        Gets the raw dictionary of the assertions params
+        Gets the raw dictionary of the assertions parameters
         :rtype: dict
         """
         return self._internal_dict
 
     def get_assertion(self, assertion_name):
         """
-        Gets a :class:`dataikuapi.dss.ml.DSSMLAssertionParams` representing the params of the assertion with the
+        Gets a :class:`dataikuapi.dss.ml.DSSMLAssertionParams` representing the parameters of the assertion with the
         provided name (or None if no assertion has that name)
         :param str assertion_name: Name of the assertion
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionParams` or None
@@ -702,18 +690,19 @@ class DSSMLAssertionsParams(object):
 
     def add_assertion(self, assertion_params):
         """
-        Adds params of an assertion to the assertions params of the ml task.
+        Adds parameters of an assertion to the assertions parameters of the ml task.
         Raises a ValueError if an assertion with the same name already exists
         :param object  assertion_params: A :class:`~dataikuapi.dss.utils.DSSMLAssertionParams` representing parameters of the assertion
         """
         if not isinstance(assertion_params, DSSMLAssertionParams):
-            raise ValueError('Wrong type for assertion params: {}'.format(type(assertion_params)))
+            raise ValueError('Wrong type for assertion parameters: {}'.format(type(assertion_params)))
         self.check_assertion_names_are_uniq(self._internal_dict["assertions"] + [assertion_params._internal_dict])
+
         self._internal_dict["assertions"].append(assertion_params._internal_dict)
 
     def delete_assertion(self, assertion_name):
         """
-        Deletes the assertion params of the assertion with the provided name from the `dataikuapi.dss.ml.DSSMLAssertionsParams`
+        Deletes the assertion parameters of the assertion with the provided name from the `dataikuapi.dss.ml.DSSMLAssertionsParams`
         Raises a ValueError if no assertion with the provided name was found
         :param str assertion_name: Name of the assertion
         """
@@ -736,7 +725,7 @@ class DSSMLAssertionParams(object):
     @staticmethod
     def create_from_parts(name, a_filter, condition):
         """
-        Creates assertion params from name, filter and condition
+        Creates assertion parameters from name, filter and condition
 
         :param str name: Name of the assertion
         :param object a_filter: A :class:`~dataikuapi.dss.utils.DSSFilter`  to select assertion population
@@ -752,7 +741,7 @@ class DSSMLAssertionParams(object):
 
     def get_raw(self):
         """
-        Gets the raw dictionary of the assertion params
+        Gets the raw dictionary of the assertion parameters
         :rtype: dict
         """
         return self._internal_dict
@@ -792,7 +781,7 @@ class DSSMLAssertionParams(object):
     @condition.setter
     def condition(self, condition):
         if not isinstance(condition, DSSMLAssertionCondition):
-            raise ValueError('Wrong type for assertion condition: {}.format(type(condition)))
+            raise ValueError('Wrong type for assertion condition: {}.format(type(condition))')
         self._internal_dict["assertionCondition"] = condition._internal_dict
 
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -797,7 +797,7 @@ class DSSMLAssertionCondition(object):
     """
       Object that represents an assertion condition
       Do not create this object directly, use :meth:`DSSMLAssertionParams.condition`, `create_from_expected_class(expected_valid_ratio, expected_class)`
-      or `create_from_expected_class(expected_valid_ratio, expected_class)` instead
+      or `create_from_expected_range(expected_valid_ratio, expected_range)` instead
     """
     def __init__(self, data):
         self._internal_dict = data

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -776,9 +776,9 @@ class DSSMLAssertionParams(object):
 
 class DSSMLAssertionCondition(object):
     """
-      Object that represents an assertion condition
-      Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionParams.condition`, :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.from_expected_class(expected_valid_ratio, expected_class)`
-      or :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.from_expected_range(expected_valid_ratio, expected_min, expected_max)` instead
+    Object that represents an assertion condition
+    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionParams.condition`, :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.from_expected_class(expected_valid_ratio, expected_class)`
+    or :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.from_expected_range(expected_valid_ratio, expected_min, expected_max)` instead
     """
     def __init__(self, data):
         self._internal_dict = data
@@ -844,7 +844,7 @@ class DSSMLAssertionCondition(object):
     def expected_valid_ratio(self):
         """
         Returns the ratio of valid rows to exceed for the assertion to pass. A row is considered valid if the prediction
-        is equal to the expected class for classification or in the expected range for regression
+        is equal to the expected class for classification or in the expected range for regression.
         :rtype: str
         """
         return self._internal_dict["successRatio"]
@@ -908,7 +908,7 @@ class DSSMLAssertionsMetrics(object):
 
         :param str assertion_name: Name of the assertion
 
-        :returns: an object representing assertion metrics or None if if no assertion with that name exists
+        :returns: an object representing assertion metrics or None if no assertion with that name exists
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionMetric`
         """
         for assertion_metric_dict in self._internal_dict["perAssertion"]:

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -892,6 +892,97 @@ class DSSMLAssertionCondition(object):
         self._internal_dict["expectedMaxValue"] = expected_range[1]
 
 
+class DSSMLAssertionsMetrics(object):
+    """
+    Object that represents the per assertion metrics for all assertions on a trained model
+    Do not create this object directly, use :meth:`DSSTrainedPredictionModelDetails.get_per_assertion_metrics()` instead
+    """
+    def __init__(self, data):
+        self._internal_dict = data
+
+    def get_raw(self):
+        """
+        Gets the raw dictionary of the assertions metrics
+        :rtype: dict
+        """
+        return self._internal_dict
+
+    def get_per_assertion_metric(self, assertion_name):
+        """
+        Retrieves the metric computed for this trained model for the assertion with the provided name (or None)
+        :returns: an object representing assertion metric
+        :rtype: `dataikuapi.dss.ml.DSSMLAssertionMetric`
+        """
+        for assertion_metric_dict in self._internal_dict["perAssertion"]:
+            if assertion_name == assertion_metric_dict["name"]:
+                return DSSMLAssertionMetric(assertion_metric_dict)
+        return None
+
+    @property
+    def positive_assertion_ratio(self):
+        """
+        Returns the ratio of passing assertions
+        :rtype: float
+        """
+        return self._internal_dict['positiveAssertionsRatio']
+
+
+class DSSMLAssertionMetric(object):
+    """
+    Object that represents the result of an assertion on a trained model
+    Do not create this object directly, use :meth:`DSSMLPerAssertionMetrics.get_assertion_metric(self, assertion_name)` instead
+    """
+    def __init__(self, data):
+        self._internal_dict = data
+
+    def get_raw(self):
+        """
+        Gets the raw dictionary of metrics of one assertion
+        :rtype: dict
+        """
+        return self._internal_dict
+
+    @property
+    def name(self):
+        """
+        Returns the assertion name
+        :rtype: str
+        """
+        return self._internal_dict["name"]
+
+    @property
+    def result(self):
+        """
+        Returns whether the assertion pass
+        :rtype: bool
+        """
+        return self._internal_dict["result"]
+
+    @property
+    def valid_ratio(self):
+        """
+        Returns the ratio of passing rows in the assertion population
+        :rtype: float
+        """
+        return self._internal_dict["validRatio"]
+
+    @property
+    def nb_matching_rows(self):
+        """
+        Returns the number of rows matching filter
+        :rtype: int
+        """
+        return self._internal_dict["nbMatchingRows"]
+
+    @property
+    def nb_dropped_rows(self):
+        """
+        Returns the number of rows dropped by the preprocessing
+        :rtype: int
+        """
+        return self._internal_dict["nbDroppedRows"]
+
+
 class DSSTreeNode(object):
     def __init__(self, tree, i):
         self.tree = tree
@@ -1050,6 +1141,22 @@ class DSSTrainedPredictionModelDetails(DSSTrainedModelDetails):
                 del clean_snippet[x]
         return clean_snippet
 
+    @property
+    def assertions_metrics(self):
+        """
+        Retrieves assertions metrics computed for this trained model
+        :returns: an object representing assertion metrics
+        :rtype: `dataikuapi.dss.ml.DSSMLAssertionsMetrics`
+        """
+        return self.get_assertions_metrics()
+
+    def get_assertions_metrics(self):
+        """
+        Retrieves assertions metrics computed for this trained model
+        :returns: an object representing assertion metrics
+        :rtype: `dataikuapi.dss.ml.DSSMLAssertionsMetrics`
+        """
+        return DSSMLAssertionsMetrics(self.snippet["assertionsMetrics"])
 
     def get_hyperparameter_search_points(self):
         """

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -716,13 +716,13 @@ class DSSMLAssertionParams(object):
     """
     Object that represents parameters for one assertion
     Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionsParams.get_assertion(assertion_name)` or
-    `create_from_parts(name, a_filter, condition)` instead
+    `from_parts(name, a_filter, condition)` instead
     """
     def __init__(self, data):
         self._internal_dict = data
 
     @staticmethod
-    def create_from_parts(name, a_filter, condition):
+    def from_parts(name, a_filter, condition):
         """
         Creates assertion parameters from name, filter and condition
 
@@ -787,14 +787,14 @@ class DSSMLAssertionParams(object):
 class DSSMLAssertionCondition(object):
     """
       Object that represents an assertion condition
-      Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionParams.condition`, :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.create_from_expected_class(expected_valid_ratio, expected_class)`
-      or :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.create_from_expected_range(expected_valid_ratio, expected_range)` instead
+      Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionParams.condition`, :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.from_expected_class(expected_valid_ratio, expected_class)`
+      or :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.from_expected_range(expected_valid_ratio, expected_range)` instead
     """
     def __init__(self, data):
         self._internal_dict = data
 
     @staticmethod
-    def create_from_expected_class(expected_valid_ratio, expected_class):
+    def from_expected_class(expected_valid_ratio, expected_class):
         """
         Creates an assertion condition from the expected valid ratio and class
 
@@ -809,7 +809,7 @@ class DSSMLAssertionCondition(object):
         return assertion_condition
 
     @staticmethod
-    def create_from_expected_range(expected_valid_ratio, expected_range):
+    def from_expected_range(expected_valid_ratio, expected_range):
         """
         Creates an assertion condition from an expected valid ratio and an expected range
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -924,7 +924,7 @@ class DSSMLAssertionCondition(object):
 
 class DSSMLAssertionsMetrics(object):
     """
-    Object that represents the per assertion metrics for all assertions on a trained model
+    Object that represents the assertions metrics for all assertions on a trained model
     Do not create this object directly, use :meth:`DSSTrainedPredictionModelDetails.get_assertions_metrics()` instead
     """
     def __init__(self, data):

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -983,7 +983,7 @@ class DSSMLAssertionMetric(object):
     @property
     def nb_dropped_rows(self):
         """
-        Returns the number of rows dropped by the preprocessing
+        Returns the number of rows dropped by the model's preprocessing
         :rtype: int
         """
         return self._internal_dict["nbDroppedRows"]

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -712,12 +712,12 @@ class DSSMLAssertionParams(object):
         self._internal_dict = data
 
     @staticmethod
-    def from_parts(name, a_filter, condition):
+    def from_params(name, a_filter, condition):
         """
         Creates assertion parameters from name, filter and condition
 
         :param str name: Name of the assertion
-        :param object a_filter: A :class:`~dataikuapi.dss.utils.DSSFilter` to select assertion population
+        :param object a_filter: A dict representing the filter to select assertion population
         :param object condition: A :class:`~dataikuapi.dss.ml.DSSMLAssertionCondition` for the assertion to be successful
 
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionParams`
@@ -751,7 +751,7 @@ class DSSMLAssertionParams(object):
     def filter(self):
         """
         Returns the assertion filter
-        :rtype: :class:`dataikuapi.dss.utils.DSSFilter`
+        :rtype: dict
         """
         return self._internal_dict["filter"]
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -431,15 +431,6 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
         """
         return PredictionSplitParamsHandler(self.mltask_settings)
 
-    @property
-    def assertions_params(self):
-        """
-        Retrieves the assertions parameters for this ml task
-
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsParams`
-        """
-        return self.get_assertions_params()
-
     def get_assertions_params(self):
         """
         Retrieves the assertions parameters for this ml task
@@ -899,7 +890,7 @@ class DSSMLAssertionCondition(object):
 class DSSMLAssertionsMetrics(object):
     """
     Object that represents the per assertion metrics for all assertions on a trained model
-    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSTrainedPredictionModelDetails.get_per_assertion_metrics()` instead
+    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSTrainedPredictionModelDetails.get_assertions_metrics()` instead
     """
     def __init__(self, data):
         self._internal_dict = data
@@ -911,13 +902,14 @@ class DSSMLAssertionsMetrics(object):
         """
         return self._internal_dict
 
-    def get_per_assertion_metric(self, assertion_name):
+    def get_metric(self, assertion_name):
         """
-        Retrieves the metric computed for this trained model for the assertion with the provided name (or None)
+        Retrieves the metric computed for this trained model for the assertion with the provided name (or None if no
+        assertion with that name exists)
 
         :param str assertion_name: Name of the assertion
 
-        :returns: an object representing assertion metrics
+        :returns: an object representing assertion metrics or None if if no assertion with that name exists
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionMetric`
         """
         for assertion_metric_dict in self._internal_dict["perAssertion"]:
@@ -937,7 +929,7 @@ class DSSMLAssertionsMetrics(object):
 class DSSMLAssertionMetric(object):
     """
     Object that represents the result of an assertion on a trained model
-    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLPerAssertionMetrics.get_assertion_metric(self, assertion_name)` instead
+    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionMetrics.get_metric(self, assertion_name)` instead
     """
     def __init__(self, data):
         self._internal_dict = data
@@ -968,7 +960,8 @@ class DSSMLAssertionMetric(object):
     @property
     def valid_ratio(self):
         """
-        Returns the ratio of passing rows in the assertion population
+        Returns the ratio of rows in the assertion population with prediction equals to the expected class
+        for classification or in the expected range for regression
         :rtype: float
         """
         return self._internal_dict["validRatio"]
@@ -1147,15 +1140,6 @@ class DSSTrainedPredictionModelDetails(DSSTrainedModelDetails):
             if x in clean_snippet:
                 del clean_snippet[x]
         return clean_snippet
-
-    @property
-    def assertions_metrics(self):
-        """
-        Retrieves assertions metrics computed for this trained model
-        :returns: an object representing assertion metrics
-        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsMetrics`
-        """
-        return self.get_assertions_metrics()
 
     def get_assertions_metrics(self):
         """

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -693,7 +693,7 @@ class DSSMLAssertionsParams(object):
         if not isinstance(assertion_params, DSSMLAssertionParams):
             raise ValueError('Wrong type for assertion parameters: {}'.format(type(assertion_params)))
 
-        self._internal_dict["assertions"].append(assertion_params._internal_dict)
+        self._internal_dict["assertions"].append(assertion_params.get_raw())
 
     def delete_assertion(self, assertion_name):
         """
@@ -786,7 +786,7 @@ class DSSMLAssertionParams(object):
     def condition(self, condition):
         if not isinstance(condition, DSSMLAssertionCondition):
             raise ValueError('Wrong type for assertion condition: {}'.format(type(condition)))
-        self._internal_dict["assertionCondition"] = condition._internal_dict
+        self._internal_dict["assertionCondition"] = condition.get_raw()
 
 
 class DSSMLAssertionCondition(object):

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -808,7 +808,7 @@ class DSSMLAssertionCondition(object):
     @staticmethod
     def create_from_expected_class(expected_valid_ratio, expected_class):
         """
-        Creates an assertion condition from an expected valid ratio and  an expected class
+        Creates an assertion condition from the expected valid ratio and class
 
         :param float expected_valid_ratio: Ratio of valid rows needed for the assertion to pass
         :param str expected_class: Class on which the `expected_valid_ratio` will be calculated

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -663,6 +663,9 @@ class DSSMLAssertionsParams(object):
     def __init__(self, data):
         self._internal_dict = data
 
+    def __repr__(self):
+        return u"{}({})".format(self.__class__.__name__, self.get_raw())
+
     def get_raw(self):
         """
         Gets the raw dictionary of the assertions parameters
@@ -920,6 +923,9 @@ class DSSMLAssertionsMetrics(object):
     def __init__(self, data):
         self._internal_dict = data
 
+    def __repr__(self):
+        return u"{}({})".format(self.__class__.__name__, self.get_raw())
+
     def get_raw(self):
         """
         Gets the raw dictionary of the assertions metrics
@@ -962,9 +968,10 @@ class DSSMLAssertionMetrics(object):
         self._internal_dict = data
 
     def __repr__(self):
-        return u"DSSMLAssertionParams(name='{}', result={}, valid_ratio={}, nb_matching_rows={}," \
-               u" nb_dropped_rows={})".format(self.name, self.result, self.valid_ratio, self.nb_matching_rows,
-                                                 self.nb_dropped_rows)
+        return u"{}(name='{}', result={}, valid_ratio={}, nb_matching_rows={}," \
+               u" nb_dropped_rows={})".format(self.__class__.__name__, self.name, self.result, self.valid_ratio,
+                                              self.nb_matching_rows, self.nb_dropped_rows)
+
     def get_raw(self):
         """
         Gets the raw dictionary of metrics of one assertion

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -731,8 +731,7 @@ class DSSMLAssertionParams(object):
         self._internal_dict = data
 
     def __repr__(self):
-        return u"DSSMLAssertionParams(name= '{name}', condition= {condition}, filter= {filter})".format(
-            name=self.name, filter=self.filter, condition=self.condition)
+        return u"{}({})".format(self.__class__.__name__, self.get_raw())
 
     @staticmethod
     def from_params(name, a_filter, condition):
@@ -812,9 +811,7 @@ class DSSMLAssertionCondition(object):
         self._internal_dict = data
 
     def __repr__(self):
-        return u"DSSMLAssertionCondition(expected_valid_ratio = {}, expected_class= {}," \
-               u" expected_min={}, expected_max={})".format(
-            self.expected_valid_ratio, self.expected_class, self.expected_min, self.expected_max)
+        return u"{}({})".format(self.__class__.__name__, self.get_raw())
 
 
     @staticmethod

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -434,7 +434,7 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
     @property
     def assertions_params(self):
         """
-        Retrieves the assertion params for this ml task
+        Retrieves the assertions params for this ml task
 
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsParams`
         """
@@ -442,7 +442,7 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
 
     def get_assertions_params(self):
         """
-        Retrieves the assertion params for this ml task
+        Retrieves the assertions params for this ml task
 
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsParams`
         """
@@ -663,11 +663,11 @@ class DSSMLDiagnostic(object):
 class DSSMLAssertionsParams(object):
     """
     Object that represents parameters for all assertions of a ml task
-    Do not create this object directly, use :meth:`DSSPredictionMLTaskSettings.get_assertion_params()` instead
+    Do not create this object directly, use :meth:`DSSPredictionMLTaskSettings.get_assertions_params()` instead
     """
 
-    @classmethod
-    def check_assertion_names_are_uniq(cls, assertion_params_list):
+    @staticmethod
+    def check_assertion_names_are_uniq(assertion_params_list):
         _ = {}
         for assertion_dict in assertion_params_list:
             if 'name' not in assertion_dict:
@@ -693,7 +693,7 @@ class DSSMLAssertionsParams(object):
         Gets a :class:`dataikuapi.dss.ml.DSSMLAssertionParams` representing the params of the assertion with the
         provided name (or None)
         :param str assertion_name: Name of the assertion
-        :rtype: `dataikuapi.dss.ml.DSSMLAssertionParams` or None
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionParams` or None
         """
         for assertion_dict in self._internal_dict["assertions"]:
             if assertion_dict["name"] == assertion_name:
@@ -702,9 +702,9 @@ class DSSMLAssertionsParams(object):
 
     def add_assertion(self, assertion_params):
         """
-        Adds params of an assertion to the assertion params of the ml task. Raises a ValueError if an assertion
-        with the same name already exists
-        :param `dataikuapi.dss.ml.DSSMLAssertionParams` assertion_params: Parameters of the assertion
+        Adds params of an assertion to the assertions params of the ml task.
+        Raises a ValueError if an assertion with the same name already exists
+        :param object  assertion_params: A :class:`~dataikuapi.dss.utils.DSSMLAssertionParams` representing parameters of the assertion
         """
         if not isinstance(assertion_params, DSSMLAssertionParams):
             raise ValueError('Assertion params should be of type: {} not {}'.format(DSSMLAssertionParams.__name__, type(assertion_params)))
@@ -736,13 +736,13 @@ class DSSMLAssertionParams(object):
     @staticmethod
     def create_from_parts(name, a_filter, condition):
         """
-        Creates a `dataikuapi.dss.ml.DSSMLAssertionParams` from name, filter and condition
+        Creates assertion params from name, filter and condition
 
         :param str name: Name of the assertion
-        :param ~dataikuapi.dss.utils.DSSFilter a_filter: Filter to select assertion population
-        :param DSSMLAssertionCondition condition: Condition for the assertion to be successful
+        :param object a_filter: A :class:`~dataikuapi.dss.utils.DSSFilter`  to select assertion population
+        :param object condition: A :class:`~dataikuapi.dss.ml.DSSMLAssertionCondition` for the assertion to be successful
 
-        :rtype: `dataikuapi.dss.ml.DSSMLAssertionParams`
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionParams`
         """
         assertion_params = DSSMLAssertionParams({})
         assertion_params.name = name
@@ -773,7 +773,7 @@ class DSSMLAssertionParams(object):
     def filter(self):
         """
         Returns the assertion filter
-        :rtype: ~dataikuapi.dss.utils.DSSFilter
+        :rtype: :class:`dataikuapi.dss.utils.DSSFilter`
         """
         return self._internal_dict["filter"]
 
@@ -785,9 +785,8 @@ class DSSMLAssertionParams(object):
     def condition(self):
         """
         Returns the assertion condition
-        :rtype: DSSMLAssertionCondition
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionCondition`
         """
-
         return DSSMLAssertionCondition(self._internal_dict["assertionCondition"])
 
     @condition.setter
@@ -800,8 +799,8 @@ class DSSMLAssertionParams(object):
 class DSSMLAssertionCondition(object):
     """
       Object that represents an assertion condition
-      Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionParams.condition`, `create_from_expected_class(expected_valid_ratio, expected_class)`
-      or `create_from_expected_range(expected_valid_ratio, expected_range)` instead
+      Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionParams.condition`, :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.create_from_expected_class(expected_valid_ratio, expected_class)`
+      or :meth:`dataikuapi.dss.ml.DSSMLAssertionCondition.create_from_expected_range(expected_valid_ratio, expected_range)` instead
     """
     def __init__(self, data):
         self._internal_dict = data
@@ -809,12 +808,12 @@ class DSSMLAssertionCondition(object):
     @staticmethod
     def create_from_expected_class(expected_valid_ratio, expected_class):
         """
-        Creates a `dataikuapi.dss.ml.DSSMLAssertionCondition` from an expected valid ratio and  an expected class
+        Creates an assertion condition from an expected valid ratio and  an expected class
 
         :param float expected_valid_ratio: Ratio of valid rows needed for the assertion to pass
         :param str expected_class: Class on which the `expected_valid_ratio` will be calculated
 
-        :rtype: `dataikuapi.dss.ml.DSSMLAssertionCondition`
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionCondition`
         """
         assertion_condition = DSSMLAssertionCondition({})
         assertion_condition.expected_valid_ratio = expected_valid_ratio
@@ -824,13 +823,13 @@ class DSSMLAssertionCondition(object):
     @staticmethod
     def create_from_expected_range(expected_valid_ratio, expected_range):
         """
-        Creates a `dataikuapi.dss.ml.DSSMLAssertionCondition` from an expected valid ratio and an expected range
+        Creates an assertion condition from an expected valid ratio and an expected range
 
         :param float expected_valid_ratio: Ratio of valid rows to exceed for the assertion to pass
         :param tuple(float,float) expected_range: Range of values (min, max) where the prediction will be considered as
         valid for the `expected_valid_ratio`
 
-        :rtype: `dataikuapi.dss.ml.DSSMLAssertionCondition`
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionCondition`
         """
         assertion_condition = DSSMLAssertionCondition({})
         assertion_condition.expected_valid_ratio = expected_valid_ratio
@@ -899,7 +898,7 @@ class DSSMLAssertionCondition(object):
 class DSSMLAssertionsMetrics(object):
     """
     Object that represents the per assertion metrics for all assertions on a trained model
-    Do not create this object directly, use :meth:`DSSTrainedPredictionModelDetails.get_per_assertion_metrics()` instead
+    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSTrainedPredictionModelDetails.get_per_assertion_metrics()` instead
     """
     def __init__(self, data):
         self._internal_dict = data
@@ -918,7 +917,7 @@ class DSSMLAssertionsMetrics(object):
         :param str assertion_name: Name of the assertion
 
         :returns: an object representing assertion metrics
-        :rtype: `dataikuapi.dss.ml.DSSMLAssertionMetric`
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionMetric`
         """
         for assertion_metric_dict in self._internal_dict["perAssertion"]:
             if assertion_name == assertion_metric_dict["name"]:
@@ -937,7 +936,7 @@ class DSSMLAssertionsMetrics(object):
 class DSSMLAssertionMetric(object):
     """
     Object that represents the result of an assertion on a trained model
-    Do not create this object directly, use :meth:`DSSMLPerAssertionMetrics.get_assertion_metric(self, assertion_name)` instead
+    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLPerAssertionMetrics.get_assertion_metric(self, assertion_name)` instead
     """
     def __init__(self, data):
         self._internal_dict = data
@@ -1153,7 +1152,7 @@ class DSSTrainedPredictionModelDetails(DSSTrainedModelDetails):
         """
         Retrieves assertions metrics computed for this trained model
         :returns: an object representing assertion metrics
-        :rtype: `dataikuapi.dss.ml.DSSMLAssertionsMetrics`
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsMetrics`
         """
         return self.get_assertions_metrics()
 
@@ -1161,7 +1160,7 @@ class DSSTrainedPredictionModelDetails(DSSTrainedModelDetails):
         """
         Retrieves assertions metrics computed for this trained model
         :returns: an object representing assertion metrics
-        :rtype: `dataikuapi.dss.ml.DSSMLAssertionsMetrics`
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsMetrics`
         """
         return DSSMLAssertionsMetrics(self.snippet["assertionsMetrics"])
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -436,7 +436,7 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
         """
         Retrieves the assertion params for this ml task
 
-        :rtype: :class:`DSSMLAssertionsParams`
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsParams`
         """
         return self.get_assertions_params()
 
@@ -444,7 +444,7 @@ class DSSPredictionMLTaskSettings(DSSMLTaskSettings):
         """
         Retrieves the assertion params for this ml task
 
-        :rtype: :class:`DSSMLAssertionsParams`
+        :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionsParams`
         """
         return DSSMLAssertionsParams(self.mltask_settings["assertionParams"])
 
@@ -690,8 +690,10 @@ class DSSMLAssertionsParams(object):
 
     def get_assertion(self, assertion_name):
         """
-        Gets a :class:`DSSMLAssertionParams` representing the params of the assertion with the provided name
-        (or None)
+        Gets a :class:`dataikuapi.dss.ml.DSSMLAssertionParams` representing the params of the assertion with the
+        provided name (or None)
+        :param str assertion_name: Name of the assertion
+        :rtype: `dataikuapi.dss.ml.DSSMLAssertionParams` or None
         """
         for assertion_dict in self._internal_dict["assertions"]:
             if assertion_dict["name"] == assertion_name:
@@ -700,8 +702,9 @@ class DSSMLAssertionsParams(object):
 
     def add_assertion(self, assertion_params):
         """
-        Adds a :class:`DSSMLAssertionParams` to the `DSSMLAssertionsParams` of the ml task. Raises a ValueError if an assertion
+        Adds params of an assertion to the assertion params of the ml task. Raises a ValueError if an assertion
         with the same name already exists
+        :param `dataikuapi.dss.ml.DSSMLAssertionParams` assertion_params: Parameters of the assertion
         """
         if not isinstance(assertion_params, DSSMLAssertionParams):
             raise ValueError('Assertion params should be of type: {} not {}'.format(DSSMLAssertionParams.__name__, type(assertion_params)))
@@ -710,8 +713,9 @@ class DSSMLAssertionsParams(object):
 
     def delete_assertion(self, assertion_name):
         """
-        Deletes the assertion params of the assertion with the provided name from the `DSSMLAssertionsParams`
+        Deletes the assertion params of the assertion with the provided name from the `dataikuapi.dss.ml.DSSMLAssertionsParams`
         Raises a ValueError if no assertion with the provided name was found
+        :param str assertion_name: Name of the assertion
         """
         for idx, assertion_dict in enumerate(self._internal_dict["assertions"]):
             if assertion_dict["name"] == assertion_name:
@@ -723,7 +727,7 @@ class DSSMLAssertionsParams(object):
 class DSSMLAssertionParams(object):
     """
     Object that represents parameters for one assertion
-    Do not create this object directly, use :meth:`DSSMLAssertionsParams.get_assertion(assertion_name)` or
+    Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionsParams.get_assertion(assertion_name)` or
     `create_from_parts(name, a_filter, condition)` instead
     """
     def __init__(self, data):
@@ -732,13 +736,13 @@ class DSSMLAssertionParams(object):
     @staticmethod
     def create_from_parts(name, a_filter, condition):
         """
-        Creates a `DSSMLAssertionParams` from name, filter and condition
+        Creates a `dataikuapi.dss.ml.DSSMLAssertionParams` from name, filter and condition
 
         :param str name: Name of the assertion
         :param ~dataikuapi.dss.utils.DSSFilter a_filter: Filter to select assertion population
         :param DSSMLAssertionCondition condition: Condition for the assertion to be successful
 
-        :rtype: DSSMLAssertionParams
+        :rtype: `dataikuapi.dss.ml.DSSMLAssertionParams`
         """
         assertion_params = DSSMLAssertionParams({})
         assertion_params.name = name
@@ -796,7 +800,7 @@ class DSSMLAssertionParams(object):
 class DSSMLAssertionCondition(object):
     """
       Object that represents an assertion condition
-      Do not create this object directly, use :meth:`DSSMLAssertionParams.condition`, `create_from_expected_class(expected_valid_ratio, expected_class)`
+      Do not create this object directly, use :meth:`dataikuapi.dss.ml.DSSMLAssertionParams.condition`, `create_from_expected_class(expected_valid_ratio, expected_class)`
       or `create_from_expected_range(expected_valid_ratio, expected_range)` instead
     """
     def __init__(self, data):
@@ -805,12 +809,12 @@ class DSSMLAssertionCondition(object):
     @staticmethod
     def create_from_expected_class(expected_valid_ratio, expected_class):
         """
-        Creates a `DSSMLAssertionCondition` from an expected valid ratio and  an expected class
+        Creates a `dataikuapi.dss.ml.DSSMLAssertionCondition` from an expected valid ratio and  an expected class
 
         :param float expected_valid_ratio: Ratio of valid rows needed for the assertion to pass
         :param str expected_class: Class on which the `expected_valid_ratio` will be calculated
 
-        :rtype: DSSMLAssertionCondition
+        :rtype: `dataikuapi.dss.ml.DSSMLAssertionCondition`
         """
         assertion_condition = DSSMLAssertionCondition({})
         assertion_condition.expected_valid_ratio = expected_valid_ratio
@@ -820,13 +824,13 @@ class DSSMLAssertionCondition(object):
     @staticmethod
     def create_from_expected_range(expected_valid_ratio, expected_range):
         """
-        Creates a `DSSMLAssertionCondition` from an expected valid ratio and an expected range
+        Creates a `dataikuapi.dss.ml.DSSMLAssertionCondition` from an expected valid ratio and an expected range
 
         :param float expected_valid_ratio: Ratio of valid rows to exceed for the assertion to pass
         :param tuple(float,float) expected_range: Range of values (min, max) where the prediction will be considered as
         valid for the `expected_valid_ratio`
 
-        :rtype: DSSMLAssertionCondition
+        :rtype: `dataikuapi.dss.ml.DSSMLAssertionCondition`
         """
         assertion_condition = DSSMLAssertionCondition({})
         assertion_condition.expected_valid_ratio = expected_valid_ratio
@@ -873,7 +877,7 @@ class DSSMLAssertionCondition(object):
     def expected_range(self):
         """
         Returns the expected range on which the valid ratio will be calculated
-        :rtype: str
+        :rtype: tuple(float,float)
         """
         if "expectedMinValue" in self._internal_dict and "expectedMaxValue" in self._internal_dict:
             return self._internal_dict["expectedMinValue"], self._internal_dict["expectedMaxValue"]
@@ -910,7 +914,9 @@ class DSSMLAssertionsMetrics(object):
     def get_per_assertion_metric(self, assertion_name):
         """
         Retrieves the metric computed for this trained model for the assertion with the provided name (or None)
-        :returns: an object representing assertion metric
+
+        :param str assertion_name: Name of the assertion
+        :returns: an object representing assertion metrics
         :rtype: `dataikuapi.dss.ml.DSSMLAssertionMetric`
         """
         for assertion_metric_dict in self._internal_dict["perAssertion"]:

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -691,7 +691,7 @@ class DSSMLAssertionsParams(object):
     def get_assertion(self, assertion_name):
         """
         Gets a :class:`dataikuapi.dss.ml.DSSMLAssertionParams` representing the params of the assertion with the
-        provided name (or None)
+        provided name (or None if no assertion has that name)
         :param str assertion_name: Name of the assertion
         :rtype: :class:`dataikuapi.dss.ml.DSSMLAssertionParams` or None
         """
@@ -721,7 +721,7 @@ class DSSMLAssertionsParams(object):
             if assertion_dict["name"] == assertion_name:
                 del self._internal_dict["assertions"][idx]
                 return
-        raise ValueError('No assertion name: {} was found'.format(assertion_name))
+        raise ValueError('No assertion found with name: {}'.format(assertion_name))
 
 
 class DSSMLAssertionParams(object):
@@ -792,7 +792,7 @@ class DSSMLAssertionParams(object):
     @condition.setter
     def condition(self, condition):
         if not isinstance(condition, DSSMLAssertionCondition):
-            raise ValueError('Condition should be of type: {} not {}'.format(DSSMLAssertionCondition.__name__, type(condition)))
+            raise ValueError('Wrong type for assertion condition: {}.format(type(condition)))
         self._internal_dict["assertionCondition"] = condition._internal_dict
 
 


### PR DESCRIPTION
First draft of methods to be added is in the [wiki](https://analytics.dataiku.com/projects/RDWIKI/wiki/972/Feature:%20ML%20assertions#public-api-1)
Can be tested with the [dip pr](https://github.com/dataiku/dip/pull/11515) that adds tests for the methods added in this PR.