### PR TITLE
Project deployer: update some PDPL methods

### DIFF
--- a/dataikuapi/dss/apideployer.py
+++ b/dataikuapi/dss/apideployer.py
@@ -60,7 +60,7 @@ class DSSAPIDeployer(object):
         """
         Lists infrastructure stages of the API Deployer
 
-        :rtype: a list of dict. Each dict contains a field "id" for the stage identifier and "desc" for its description.
+        :rtype: list of dict. Each dict contains a field "id" for the stage identifier and "desc" for its description.
         :rtype: list
         """
         return self.client._perform_json("GET", "/api-deployer/stages")
@@ -167,7 +167,7 @@ class DSSAPIDeployerInfra(object):
         """
         Returns status information about this infrastructure
 
-        :rtype: a :class:`dataikuapi.dss.apideployer.DSSAPIDeployerInfraStatus`
+        :rtype: :class:`dataikuapi.dss.apideployer.DSSAPIDeployerInfraStatus`
         """
         light = self.client._perform_json("GET", "/api-deployer/infras/%s" % (self.infra_id))
 
@@ -272,6 +272,7 @@ class DSSAPIDeployerInfraStatus(object):
     def get_raw(self):
         """
         Gets the raw status information. This returns a dictionary with various information about the infrastructure
+
         :rtype: dict
         """
         return self.light_status
@@ -295,7 +296,8 @@ class DSSAPIDeployerDeployment(object):
         return self.deployment_id
 
     def get_status(self):
-        """Returns status information about this deployment
+        """
+        Returns status information about this deployment
 
         :rtype: dataikuapi.dss.apideployer.DSSAPIDeployerDeploymentStatus
         """
@@ -341,7 +343,8 @@ class DSSAPIDeployerDeployment(object):
 
 
 class DSSAPIDeployerDeploymentSettings(object):
-    """The settings of an API Deployer deployment. 
+    """
+    The settings of an API Deployer deployment. 
 
     Do not create this directly, use :meth:`~dataikuapi.dss.apideployer.DSSAPIDeployerDeployment.get_settings`
     """
@@ -360,7 +363,9 @@ class DSSAPIDeployerDeploymentSettings(object):
         return self.settings
 
     def set_enabled(self, enabled):
-        """Enables or disables this deployment"""
+        """
+        Enables or disables this deployment
+        """
         self.settings["enabled"] = enabled
 
     def set_single_version(self, version):
@@ -375,14 +380,17 @@ class DSSAPIDeployerDeploymentSettings(object):
         }
         
     def save(self):
-        """Saves back these settings to the deployment"""
+        """
+        Saves back these settings to the deployment
+        """
         self.client._perform_empty(
                 "PUT", "/api-deployer/deployments/%s/settings" % (self.deployment_id),
                 body = self.settings)
 
 
 class DSSAPIDeployerDeploymentStatus(object):
-    """The status of an API Deployer deployment. 
+    """
+    The status of an API Deployer deployment. 
 
     Do not create this directly, use :meth:`~dataikuapi.dss.apideployer.DSSAPIDeployerDeployment.get_status`
     """
@@ -404,12 +412,15 @@ class DSSAPIDeployerDeploymentStatus(object):
     def get_heavy(self):
         """
         Gets the 'heavy' (full) status. This returns a dictionary with various information about the deployment
+
         :rtype: dict
         """
         return self.heavy_status
 
     def get_service_urls(self):
-        """Returns service-level URLs for this deployment (ie without the enpdoint-specific suffix)"""
+        """
+        Returns service-level URLs for this deployment (ie without the enpdoint-specific suffix)
+        """
 
         if "deployedServiceId" in self.light_status["deploymentBasicInfo"]:
             service_id = self.light_status["deploymentBasicInfo"]["deployedServiceId"]
@@ -424,7 +435,8 @@ class DSSAPIDeployerDeploymentStatus(object):
             raise ValueError("PublicURL not available for this deployment. It might still be initializing")
 
     def get_health(self):
-        """Returns the health of this deployment as a string
+        """
+        Returns the health of this deployment as a string
 
         :returns: HEALTHY if the deployment is working properly, various other status otherwise
         :rtype: string
@@ -491,6 +503,7 @@ class DSSAPIDeployerService(object):
     def delete_version(self, version):
         """
         Deletes a version from this service
+
         :param string version: The version to delete
         """
         self.client._perform_empty(
@@ -507,7 +520,8 @@ class DSSAPIDeployerService(object):
 
 
 class DSSAPIDeployerServiceSettings(object):
-    """The settings of an API Deployer Service. 
+    """
+    The settings of an API Deployer Service. 
 
     Do not create this directly, use :meth:`~dataikuapi.dss.apideployer.DSSAPIDeployerService.get_settings`
     """
@@ -526,14 +540,17 @@ class DSSAPIDeployerServiceSettings(object):
         return self.settings
 
     def save(self):
-        """Saves back these settings to the API service"""
+        """
+        Saves back these settings to the API service
+        """
         self.client._perform_empty(
                 "PUT", "/api-deployer/services/%s/settings" % (self.service_id),
                 body = self.settings)
 
 
 class DSSAPIDeployerServiceStatus(object):
-    """The status of an API Deployer Service. 
+    """
+    The status of an API Deployer Service. 
 
     Do not create this directly, use :meth:`~dataikuapi.dss.apideployer.DSSAPIDeployerService.get_status`
     """
@@ -556,6 +573,7 @@ class DSSAPIDeployerServiceStatus(object):
     def get_raw(self):
         """
         Gets the raw status information. This returns a dictionary with various information about the service,
+
         :rtype: dict
         """
         return self.light_status

--- a/dataikuapi/dss/apideployer.py
+++ b/dataikuapi/dss/apideployer.py
@@ -152,7 +152,7 @@ class DSSAPIDeployer(object):
 
 class DSSAPIDeployerInfra(object):
     """
-    A Deployment infrastructure on the API Deployer
+    An API Deployer infrastructure.
 
     Do not create this directly, use :meth:`~dataikuapi.dss.apideployer.DSSAPIDeployer.get_infra`
     """
@@ -162,6 +162,16 @@ class DSSAPIDeployerInfra(object):
 
     def id(self):
         return self.infra_id
+
+    def get_status(self):
+        """
+        Returns status information about this infrastructure
+
+        :rtype: a :class:`dataikuapi.dss.apideployer.DSSAPIDeployerInfraStatus`
+        """
+        light = self.client._perform_json("GET", "/api-deployer/infras/%s" % (self.infra_id))
+
+        return DSSAPIDeployerInfraStatus(self.client, self.infra_id, light)
 
     def get_settings(self):
         """
@@ -186,7 +196,8 @@ class DSSAPIDeployerInfra(object):
 
 
 class DSSAPIDeployerInfraSettings(object):
-    """The settings of an API Deployer Infra. 
+    """
+    The settings of an API Deployer infrastructure
 
     Do not create this directly, use :meth:`~dataikuapi.dss.apideployer.DSSAPIDeployerInfra.get_settings`
     """
@@ -236,6 +247,34 @@ class DSSAPIDeployerInfraSettings(object):
         self.client._perform_empty(
                 "PUT", "/api-deployer/infras/%s/settings" % (self.infra_id),
                 body = self.settings)
+
+
+class DSSAPIDeployerInfraStatus(object):
+    """
+    The status of an API Deployer infrastructure.
+
+    Do not create this directly, use :meth:`~dataikuapi.dss.apideployer.DSSAPIDeployerInfra.get_status`
+    """
+    def __init__(self, client, infra_id, light_status):
+        self.client = client
+        self.infra_id = infra_id
+        self.light_status = light_status
+
+    def list_deployments(self):
+        """
+        Returns the deployments that are deployed on this infrastructure
+
+        :returns: a list of deployments
+        :rtype: list of :class:`dataikuapi.dss.apideployer.DSSAPIDeployerDeployment`
+        """
+        return [DSSAPIDeployerDeployment(self.client, deployment.id) for deployment in self.light_status["deployments"]]
+
+    def get_raw(self):
+        """
+        Gets the raw status information. This returns a dictionary with various information about the infrastructure
+        :rtype: dict
+        """
+        return self.light_status
 
 
 ###############################################

--- a/dataikuapi/dss/apideployer.py
+++ b/dataikuapi/dss/apideployer.py
@@ -260,7 +260,7 @@ class DSSAPIDeployerInfraStatus(object):
         self.infra_id = infra_id
         self.light_status = light_status
 
-    def list_deployments(self):
+    def get_deployments(self):
         """
         Returns the deployments that are deployed on this infrastructure
 
@@ -558,6 +558,20 @@ class DSSAPIDeployerServiceStatus(object):
         self.client = client
         self.service_id = service_id
         self.light_status = light_status
+
+    def get_deployments(self, infra_id=None):
+        """
+        Returns the deployments that have been created from this published project
+
+        :param str infra_id: Identifier of an infra, allows to only keep in the returned list the deployments on this infra.
+        If not set, the list contains all the deployments using this published project, across every infra of the Project Deployer.
+
+        :returns: a list of deployments
+        :rtype: list of :class:`dataikuapi.dss.apideployer.DSSAPIDeployerDeployment`
+        """
+        if infra_id is None:
+            return [DSSAPIDeployerDeployment(self.client, deployment["id"]) for deployment in self.light_status["deployments"]]
+        return [DSSAPIDeployerDeployment(self.client, deployment["id"]) for deployment in self.light_status["deployments"] if infra_id == deployment["infraId"]]
 
     def get_versions(self):
         """

--- a/dataikuapi/dss/apideployer.py
+++ b/dataikuapi/dss/apideployer.py
@@ -267,7 +267,7 @@ class DSSAPIDeployerInfraStatus(object):
         :returns: a list of deployments
         :rtype: list of :class:`dataikuapi.dss.apideployer.DSSAPIDeployerDeployment`
         """
-        return [DSSAPIDeployerDeployment(self.client, deployment.id) for deployment in self.light_status["deployments"]]
+        return [DSSAPIDeployerDeployment(self.client, deployment["id"]) for deployment in self.light_status["deployments"]]
 
     def get_raw(self):
         """

--- a/dataikuapi/dss/apideployer.py
+++ b/dataikuapi/dss/apideployer.py
@@ -1,6 +1,6 @@
 import json
 from .future import DSSFuture
-
+from ..utils import CallableStr
 
 class DSSAPIDeployer(object):
     """
@@ -160,8 +160,9 @@ class DSSAPIDeployerInfra(object):
         self.client = client
         self.infra_id = infra_id
 
+    @property
     def id(self):
-        return self.infra_id
+        return CallableStr(self.infra_id)
 
     def get_status(self):
         """
@@ -292,8 +293,9 @@ class DSSAPIDeployerDeployment(object):
         self.client = client
         self.deployment_id = deployment_id
 
+    @property
     def id(self):
-        return self.deployment_id
+        return CallableStr(self.deployment_id)
 
     def get_status(self):
         """
@@ -462,8 +464,9 @@ class DSSAPIDeployerService(object):
         self.client = client
         self.service_id = service_id
 
+    @property
     def id(self):
-        return self.service_id
+        return CallableStr(self.service_id)
 
     def get_status(self):
         """

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -958,7 +958,8 @@ class DSSProject(object):
     def download_exported_bundle_archive_to_file(self, bundle_id, path):
         """
         Download a bundle archive that can be deployed in a DSS automation Node into the given output file.
-        @param path if "-", will write to /dev/stdout
+        
+        :param path if "-", will write to /dev/stdout
         """
         if path == "-":
             path= "/dev/stdout"
@@ -974,6 +975,7 @@ class DSSProject(object):
     def publish_bundle(self, bundle_id, published_project_key=None):
         """
         Publish a bundle on the Project Deployer.
+
         :param string bundle_id: The identifier of the bundle
         :param string published_project_key: The key of the project on the Project Deployer where the bundle will be published.
             A new published project will be created if none matches the key.

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -936,7 +936,7 @@ class DSSProject(object):
         return DSSAPIService(self.client, self.project_key, service_id)
 
     ########################################################
-    # Bundles / Export (Design node)
+    # Bundles / Export and Publish (Design node)
     ########################################################
 
     def list_exported_bundles(self):
@@ -971,6 +971,18 @@ class DSSProject(object):
                     f.flush()
         stream.close()
 
+    def publish_bundle(self, bundle_id, published_project_key=None):
+        """
+        Publish a bundle on the Project Deployer.
+        :param string bundle_id: The identifier of the bundle
+        :param string published_project_key: The key of the project on the Project Deployer where the bundle will be published.
+            A new published project will be created if none matches the key.
+            If the parameter is not set, the key from the current :class:`DSSProject` is used.
+        """
+        params = None
+        if published_project_key is not None:
+            params = {"publishedProjectKey": published_project_key}
+        return self.client._perform_json("GET", "/projects/%s/bundles/%s/publish" % (self.project_key, bundle_id), params=params)
 
     ########################################################
     # Bundles / Import (Automation node)

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -982,8 +982,8 @@ class DSSProject(object):
             If the parameter is not set, the key from the current :class:`DSSProject` is used.
 
         :rtype: dict
-        :return: a dict with info on the bundle state once published. It contains the keys "publishedOn" for the date on which the publication was done,
-        "publishedBy" for the user whom performed it, "publishedProjectKey" for the key of the Project Deployer project used.
+        :return: a dict with info on the bundle state once published. It contains the keys "publishedOn" for the publish date,
+        "publishedBy" for the user who published the bundle, and "publishedProjectKey" for the key of the Project Deployer project used.
         """
         params = None
         if published_project_key is not None:

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -980,6 +980,10 @@ class DSSProject(object):
         :param string published_project_key: The key of the project on the Project Deployer where the bundle will be published.
             A new published project will be created if none matches the key.
             If the parameter is not set, the key from the current :class:`DSSProject` is used.
+
+        :rtype: dict
+        :return: a dict with info on the bundle state once published. It contains the keys "publishedOn" for the date on which the publication was done,
+        "publishedBy" for the user whom performed it, "publishedProjectKey" for the key of the Project Deployer project used.
         """
         params = None
         if published_project_key is not None:

--- a/dataikuapi/dss/projectdeployer.py
+++ b/dataikuapi/dss/projectdeployer.py
@@ -532,7 +532,7 @@ class DSSProjectDeployerProjectStatus(object):
         """
         if infra_id is None:
             return [DSSProjectDeployerDeployment(self.client, deployment["id"]) for deployment in self.light_status["deployments"]]
-        return [DSSProjectDeployerDeployment(self.client, deployment["id"]) for deployment in self.light_status["deployments"] if infra_id == deployment.infraId]
+        return [DSSProjectDeployerDeployment(self.client, deployment["id"]) for deployment in self.light_status["deployments"] if infra_id == deployment["infraId"]]
 
     def get_bundles(self):
         """

--- a/dataikuapi/dss/projectdeployer.py
+++ b/dataikuapi/dss/projectdeployer.py
@@ -152,6 +152,23 @@ class DSSProjectDeployer(object):
         """
         return DSSProjectDeployerProject(self.client, project_key)
 
+    def upload_bundle(self, fp, project_key=None):
+        """
+        Uploads a new version for a project from a file-like object pointing
+        to a bundle Zip file.
+        :param string fp: A file-like object pointing to a bundle Zip file
+        :param string project_key: The key of the published project where the bundle will be uploaded. If the project does not exist, it is created.
+        If not set, the key of the bundle's source project is used.
+
+        """
+        if project_key is None:
+            params = None
+        else:
+            params = {
+                "projectKey": project_key,
+            }
+        return self.client._perform_empty("POST",
+                "/project-deployer/projects/bundles", params=params, files={"file":fp})
 
 ###############################################
 # Infrastructures
@@ -374,24 +391,6 @@ class DSSProjectDeployerProject(object):
         """
         light = self.client._perform_json("GET", "/project-deployer/projects/%s" % (self.project_key))
         return DSSProjectDeployerProjectStatus(self.client, self.project_key, light)
-
-    def import_bundle(self, fp, design_node_url=None, design_node_id=None):
-        """
-        Imports a new version for a project from a file-like object pointing
-        to a bundle Zip file.
-        :param string fp: A file-like object pointing to a bundle Zip file
-        :param string design_node_url: The URL of the Design node where the bundle was created
-        :param design_node_id: The identifier of the Design node where the bundle was created
-        """
-        if design_node_url is None and design_node_id is None:
-            params = None
-        else:
-            params = {
-                "designNodeId": design_node_id,
-                "designNodeUrl": design_node_url
-            }
-        return self.client._perform_empty("POST",
-                "/project-deployer/projects/%s/bundles" % (self.project_key), params=params, files={"file":fp})
 
     def get_settings(self):
         """

--- a/dataikuapi/dss/projectdeployer.py
+++ b/dataikuapi/dss/projectdeployer.py
@@ -471,7 +471,8 @@ class DSSProjectDeployerProjectSettings(object):
 
 
 class DSSProjectDeployerProjectStatus(object):
-    """The status of a published project.
+    """
+    The status of a published project.
 
     Do not create this directly, use :meth:`~dataikuapi.dss.projectdeployer.DSSProjectDeployerProject.get_status`
     """
@@ -479,6 +480,20 @@ class DSSProjectDeployerProjectStatus(object):
         self.client = client
         self.project_key = project_key
         self.light_status = light_status
+
+    def list_deployments(self, infra_id=None):
+        """
+        Returns the deployments that have been created from this published project
+
+        :param str infra_id: Identifier of an infra, allows to only keep in the returned list the deployments on this infra.
+        If not set, the list contains all the deployments using this published project, across every infra of the Project Deployer.
+
+        :returns: a list of deployments
+        :rtype: list of :class:`dataikuapi.dss.projectdeployer.DSSProjectDeployerDeployment`
+        """
+        if infra_id is None:
+            return [DSSProjectDeployerDeployment(self.client, deployment.id) for deployment in self.light_status["deployments"]]
+        return [DSSProjectDeployerDeployment(self.client, deployment.id) for deployment in self.light_status["deployments"] if infra_id == deployment.infraId]
 
     def get_bundles(self):
         """

--- a/dataikuapi/dss/projectdeployer.py
+++ b/dataikuapi/dss/projectdeployer.py
@@ -177,7 +177,7 @@ class DSSProjectDeployer(object):
 
 class DSSProjectDeployerInfra(object):
     """
-    A Deployment infrastructure on the Project Deployer
+    An Automation infrastructure on the Project Deployer
 
     Do not create this directly, use :meth:`~dataikuapi.dss.projectdeployer.DSSProjectDeployer.get_infra`
     """
@@ -187,6 +187,16 @@ class DSSProjectDeployerInfra(object):
 
     def id(self):
         return self.infra_id
+
+    def get_status(self):
+        """
+        Returns status information about this infrastructure
+
+        :rtype: a :class:`dataikuapi.dss.projectdeployer.DSSProjectDeployerInfraStatus`
+        """
+        light = self.client._perform_json("GET", "/project-deployer/infras/%s" % (self.infra_id))
+
+        return DSSProjectDeployerInfraStatus(self.client, self.infra_id, light)
 
     def get_settings(self):
         """
@@ -211,7 +221,8 @@ class DSSProjectDeployerInfra(object):
 
 
 class DSSProjectDeployerInfraSettings(object):
-    """The settings of a Project Deployer Infra.
+    """
+    The settings of an Automation infrastructure.
 
     Do not create this directly, use :meth:`~dataikuapi.dss.projectdeployer.DSSProjectDeployerInfra.get_settings`
     """
@@ -235,6 +246,33 @@ class DSSProjectDeployerInfraSettings(object):
                 "PUT", "/project-deployer/infras/%s/settings" % (self.infra_id),
                 body = self.settings)
 
+
+class DSSProjectDeployerInfraStatus(object):
+    """
+    The status of an Automation infrastructure.
+
+    Do not create this directly, use :meth:`~dataikuapi.dss.projectdeployer.DSSProjectDeployerInfra.get_status`
+    """
+    def __init__(self, client, infra_id, light_status):
+        self.client = client
+        self.infra_id = infra_id
+        self.light_status = light_status
+
+    def list_deployments(self):
+        """
+        Returns the deployments that are deployed on this infrastructure
+
+        :returns: a list of deployments
+        :rtype: list of :class:`dataikuapi.dss.projectdeployer.DSSProjectDeployerDeployment`
+        """
+        return [DSSProjectDeployerDeployment(self.client, deployment.id) for deployment in self.light_status["deployments"]]
+
+    def get_raw(self):
+        """
+        Gets the raw status information. This returns a dictionary with various information about the infrastructure
+        :rtype: dict
+        """
+        return self.light_status
 
 ###############################################
 # Deployments
@@ -443,6 +481,7 @@ class DSSProjectDeployerProject(object):
         """
         return self.client._perform_empty(
             "DELETE", "/project-deployer/projects/%s" % (self.project_key))
+
 
 class DSSProjectDeployerProjectSettings(object):
     """The settings of a published project.

--- a/dataikuapi/dss/projectdeployer.py
+++ b/dataikuapi/dss/projectdeployer.py
@@ -69,7 +69,7 @@ class DSSProjectDeployer(object):
         """
         Lists infrastructure stages of the Project Deployer
 
-        :rtype: a list of dict. Each dict contains a field "id" for the stage identifier and "desc" for its description.
+        :rtype: list of dict. Each dict contains a field "id" for the stage identifier and "desc" for its description.
         :rtype: list
         """
         return self.client._perform_json("GET", "/project-deployer/stages")
@@ -156,6 +156,7 @@ class DSSProjectDeployer(object):
         """
         Uploads a new version for a project from a file-like object pointing
         to a bundle Zip file.
+
         :param string fp: A file-like object pointing to a bundle Zip file
         :param string project_key: The key of the published project where the bundle will be uploaded. If the project does not exist, it is created.
         If not set, the key of the bundle's source project is used.
@@ -193,7 +194,7 @@ class DSSProjectDeployerInfra(object):
         """
         Returns status information about this infrastructure
 
-        :rtype: a :class:`dataikuapi.dss.projectdeployer.DSSProjectDeployerInfraStatus`
+        :rtype: :class:`dataikuapi.dss.projectdeployer.DSSProjectDeployerInfraStatus`
         """
         light = self.client._perform_json("GET", "/project-deployer/infras/%s" % (self.infra_id))
 
@@ -242,7 +243,9 @@ class DSSProjectDeployerInfraSettings(object):
         return self.settings
 
     def save(self):
-        """Saves back these settings to the infra"""
+        """
+        Saves back these settings to the infra
+        """
         self.client._perform_empty(
                 "PUT", "/project-deployer/infras/%s/settings" % (self.infra_id),
                 body = self.settings)
@@ -271,6 +274,7 @@ class DSSProjectDeployerInfraStatus(object):
     def get_raw(self):
         """
         Gets the raw status information. This returns a dictionary with various information about the infrastructure
+
         :rtype: dict
         """
         return self.light_status
@@ -295,7 +299,8 @@ class DSSProjectDeployerDeployment(object):
         return self.deployment_id
 
     def get_status(self):
-        """Returns status information about this deployment
+        """
+        Returns status information about this deployment
 
         :rtype: dataikuapi.dss.apideployer.DSSProjectDeployerDeploymentStatus
         """
@@ -400,12 +405,14 @@ class DSSProjectDeployerDeploymentStatus(object):
     def get_heavy(self):
         """
         Gets the 'heavy' (full) status. This returns a dictionary with various information about the deployment
+
         :rtype: dict
         """
         return self.heavy_status
 
     def get_health(self):
-        """Returns the health of this deployment as a string
+        """
+        Returns the health of this deployment as a string
 
         :returns: HEALTHY if the deployment is working properly, various other status otherwise
         :rtype: string
@@ -413,7 +420,9 @@ class DSSProjectDeployerDeploymentStatus(object):
         return self.heavy_status["health"]
 
     def get_health_messages(self):
-        """Returns messages about the health of this deployment"""
+        """
+        Returns messages about the health of this deployment
+        """
         return self.heavy_status["healthMessages"]
 
 ###############################################
@@ -462,6 +471,7 @@ class DSSProjectDeployerProject(object):
     def delete_bundle(self, bundle_id):
         """
         Deletes a bundle from this project
+
         :param string bundle_id: The identifier of the bundle to delete
         """
         self.client._perform_empty(
@@ -497,7 +507,9 @@ class DSSProjectDeployerProjectSettings(object):
         return self.settings
 
     def save(self):
-        """Saves back these settings to the project"""
+        """
+        Saves back these settings to the project
+        """
         self.client._perform_empty(
                 "PUT", "/project-deployer/projects/%s/settings" % (self.project_key),
                 body = self.settings)
@@ -542,6 +554,7 @@ class DSSProjectDeployerProjectStatus(object):
     def get_raw(self):
         """
         Gets the raw status information. This returns a dictionary with various information about the project
+
         :rtype: dict
         """
         return self.light_status

--- a/dataikuapi/dss/projectdeployer.py
+++ b/dataikuapi/dss/projectdeployer.py
@@ -319,8 +319,28 @@ class DSSProjectDeployerDeploymentSettings(object):
         """
         return self.settings
 
+    def get_bundle_id(self):
+        """
+        Gets the bundle id currently used by this deployment.
+
+        :rtype: str
+        """
+        return self.settings["bundleId"]
+
+    def set_bundle_id(self, new_bundle_id):
+        """
+        Sets a new bundle id for this deployment. You need to call :meth:`~dataikuapi.dss.projectdeployer.DSSProjectDeployerDeployment.get_settings`
+        afterwards for the change to be effective.
+
+        :param str new_bundle_id: Identifier of the bundle to be set
+        """
+        self.settings["bundleId"] = new_bundle_id
+
+
     def save(self):
-        """Saves back these settings to the deployment"""
+        """
+        Saves back these settings to the deployment
+        """
         self.client._perform_empty(
                 "PUT", "/project-deployer/deployments/%s/settings" % (self.deployment_id),
                 body = self.settings)

--- a/dataikuapi/dss/projectdeployer.py
+++ b/dataikuapi/dss/projectdeployer.py
@@ -185,6 +185,7 @@ class DSSProjectDeployerInfra(object):
         self.client = client
         self.infra_id = infra_id
 
+    @property
     def id(self):
         return self.infra_id
 
@@ -289,6 +290,7 @@ class DSSProjectDeployerDeployment(object):
         self.client = client
         self.deployment_id = deployment_id
 
+    @property
     def id(self):
         return self.deployment_id
 
@@ -357,23 +359,14 @@ class DSSProjectDeployerDeploymentSettings(object):
         """
         return self.settings
 
-    def get_bundle_id(self):
+    @property
+    def bundle_id(self):
         """
         Gets the bundle id currently used by this deployment.
 
         :rtype: str
         """
         return self.settings["bundleId"]
-
-    def set_bundle_id(self, new_bundle_id):
-        """
-        Sets a new bundle id for this deployment. You need to call :meth:`~dataikuapi.dss.projectdeployer.DSSProjectDeployerDeployment.get_settings`
-        afterwards for the change to be effective.
-
-        :param str new_bundle_id: Identifier of the bundle to be set
-        """
-        self.settings["bundleId"] = new_bundle_id
-
 
     def save(self):
         """
@@ -437,6 +430,7 @@ class DSSProjectDeployerProject(object):
         self.client = client
         self.project_key = project_key
 
+    @property
     def id(self):
         return self.project_key
 

--- a/dataikuapi/dss/projectdeployer.py
+++ b/dataikuapi/dss/projectdeployer.py
@@ -262,7 +262,7 @@ class DSSProjectDeployerInfraStatus(object):
         self.infra_id = infra_id
         self.light_status = light_status
 
-    def list_deployments(self):
+    def get_deployments(self):
         """
         Returns the deployments that are deployed on this infrastructure
 
@@ -526,7 +526,7 @@ class DSSProjectDeployerProjectStatus(object):
         self.project_key = project_key
         self.light_status = light_status
 
-    def list_deployments(self, infra_id=None):
+    def get_deployments(self, infra_id=None):
         """
         Returns the deployments that have been created from this published project
 

--- a/dataikuapi/dss/projectdeployer.py
+++ b/dataikuapi/dss/projectdeployer.py
@@ -265,7 +265,7 @@ class DSSProjectDeployerInfraStatus(object):
         :returns: a list of deployments
         :rtype: list of :class:`dataikuapi.dss.projectdeployer.DSSProjectDeployerDeployment`
         """
-        return [DSSProjectDeployerDeployment(self.client, deployment.id) for deployment in self.light_status["deployments"]]
+        return [DSSProjectDeployerDeployment(self.client, deployment["id"]) for deployment in self.light_status["deployments"]]
 
     def get_raw(self):
         """
@@ -531,8 +531,8 @@ class DSSProjectDeployerProjectStatus(object):
         :rtype: list of :class:`dataikuapi.dss.projectdeployer.DSSProjectDeployerDeployment`
         """
         if infra_id is None:
-            return [DSSProjectDeployerDeployment(self.client, deployment.id) for deployment in self.light_status["deployments"]]
-        return [DSSProjectDeployerDeployment(self.client, deployment.id) for deployment in self.light_status["deployments"] if infra_id == deployment.infraId]
+            return [DSSProjectDeployerDeployment(self.client, deployment["id"]) for deployment in self.light_status["deployments"]]
+        return [DSSProjectDeployerDeployment(self.client, deployment["id"]) for deployment in self.light_status["deployments"] if infra_id == deployment.infraId]
 
     def get_bundles(self):
         """

--- a/dataikuapi/utils.py
+++ b/dataikuapi/utils.py
@@ -94,3 +94,10 @@ class DataikuStreamedHttpUTF8CSVReader(object):
                                                 doublequote=True):
                 yield [none_if_throws(caster)(val)
                         for (caster, val) in dku_zip_longest(casters, uncasted_tuple)]
+
+class CallableStr(str):
+    def __init__(self, val):
+        self.val = val
+
+    def __call__(self):
+        return self.val


### PR DESCRIPTION
[ch59800](https://app.clubhouse.io/dataiku/story/59800/feedback-on-apis-for-pdpl)

A PR is opened to add the API in the doc: https://github.com/dataiku/dss-doc/pull/458

- Move and rename `DSSProjectDeployerProject#import_bundle` (to `DSSProjectDeployer#upload_bundle`)
   - Do not pass design node info as params anymore
   - Pass the published key as a param (to match what we do in the UI)
- `DSSProjectDeployerDeploymentSettings`: add a property `bundle_id`
- Add a `DSSProjectDeployerProjectStatus#get_deployments` method
- Add wrapper classes for infra (`DSSProjectDeployerInfraStatus`/`DSSAPIDeployerInfraStatus`)
   - ~`DSSAPIDeployerInfra#get_status`/`DSSAPIDeployerInfra#get_status` corresponding public API calls are implemented in https://github.com/dataiku/dip/pull/12012~ (now merged)
- Add a `DSSProject#publish_bundle` method
   - ~corresponding public API call in https://github.com/dataiku/dip/pull/12012~ (now merged)