### PR TITLE
ML Task Queues - Train queue + list queues

### DIFF
--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -3328,15 +3328,15 @@ class DSSMLTask(object):
         self.client._perform_empty(
             "DELETE", "/projects/%s/models/lab/%s/%s/models/%s" % (self.project_key, self.analysis_id, self.mltask_id, model_id))
 
-    def resume_queue(self):
+    def train_queue(self):
         """
-        Resumes a paused queue
+        Trains a queue
 
-        :return: A dict including the sessionID of the resumed queue
+        :return: A dict including the next sessionID to be trained in the queue
         :rtype dict
         """
         return self.client._perform_json(
-            "POST", "/projects/%s/models/lab/%s/%s/actions/resumeQueue" % (self.project_key, self.analysis_id, self.mltask_id))
+            "POST", "/projects/%s/models/lab/%s/%s/actions/trainQueue" % (self.project_key, self.analysis_id, self.mltask_id))
 
     def deploy_to_flow(self, model_id, model_name, train_dataset, test_dataset=None, redo_optimization=True):
         """

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -3328,6 +3328,16 @@ class DSSMLTask(object):
         self.client._perform_empty(
             "DELETE", "/projects/%s/models/lab/%s/%s/models/%s" % (self.project_key, self.analysis_id, self.mltask_id, model_id))
 
+    def resume_queue(self):
+        """
+        Resumes a paused queue
+
+        :return: A dict including the sessionID of the resumed queue
+        :rtype dict
+        """
+        return self.client._perform_json(
+            "POST", "/projects/%s/models/lab/%s/%s/actions/resumeQueue" % (self.project_key, self.analysis_id, self.mltask_id))
+
     def deploy_to_flow(self, model_id, model_name, train_dataset, test_dataset=None, redo_optimization=True):
         """
         Deploys a trained model from this ML Task to a saved model + train recipe in the Flow.

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -3336,7 +3336,7 @@ class DSSMLTask(object):
         :rtype dict
         """
         return self.client._perform_json(
-            "POST", "/projects/%s/models/lab/%s/%s/actions/trainQueue" % (self.project_key, self.analysis_id, self.mltask_id))
+            "POST", "/projects/%s/models/lab/%s/%s/actions/train-queue" % (self.project_key, self.analysis_id, self.mltask_id))
 
     def deploy_to_flow(self, model_id, model_name, train_dataset, test_dataset=None, redo_optimization=True):
         """

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -3427,10 +3427,13 @@ class DSSMLTask(object):
 
 class DSSMLTaskQueues(object):
     """
-    Object containing a list of MLTask queues
+    Iterable listing of MLTask queues
     """
-    def __init__(self, queues):
-        self.queues = queues
+    def __init__(self, data):
+        self.data = data
 
     def __iter__(self):
-        return self.queues.__iter__()
+        return self.data["queues"].__iter__()
+
+    def get_raw(self):
+        return self.data

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -3330,7 +3330,7 @@ class DSSMLTask(object):
 
     def train_queue(self):
         """
-        Trains a queue
+        Trains this MLTask's queue
 
         :return: A dict including the next sessionID to be trained in the queue
         :rtype dict

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -3155,7 +3155,7 @@ class DSSMLTask(object):
         else:
             return DSSClusteringMLTaskSettings(self.client, self.project_key, self.analysis_id, self.mltask_id, settings)
 
-    def train(self, session_name=None, session_description=None):
+    def train(self, session_name=None, session_description=None, run_queue=False):
         """
         Trains models for this ML Task
         
@@ -3173,7 +3173,7 @@ class DSSMLTask(object):
         :return: A list of model identifiers
         :rtype: list of strings
         """
-        train_ret = self.start_train(session_name, session_description)
+        train_ret = self.start_train(session_name, session_description, run_queue)
         self.wait_train_complete()
         return self.get_trained_models_ids(session_id = train_ret["sessionId"])
 
@@ -3202,7 +3202,7 @@ class DSSMLTask(object):
         return train_ret
 
 
-    def start_train(self, session_name=None, session_description=None):
+    def start_train(self, session_name=None, session_description=None, run_queue=False):
         """
         Starts asynchronously a new train session for this ML Task.
 
@@ -3213,7 +3213,8 @@ class DSSMLTask(object):
         """
         session_info = {
                             "sessionName" : session_name,
-                            "sessionDescription" : session_description
+                            "sessionDescription" : session_description,
+                            "runQueue": run_queue
                         }
 
         return self.client._perform_json(

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -3423,3 +3423,14 @@ class DSSMLTask(object):
             "PUT",
             "/projects/%s/models/lab/%s/%s/guess" % (self.project_key, self.analysis_id, self.mltask_id),
             params = obj)
+
+
+class DSSMLTaskQueues(object):
+    """
+    Object containing a list of MLTask queues
+    """
+    def __init__(self, queues):
+        self.queues = queues
+
+    def __iter__(self):
+        return self.queues.__iter__()

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -15,7 +15,7 @@ from .notebook import DSSNotebook
 from .macro import DSSMacro
 from .wiki import DSSWiki
 from .discussion import DSSObjectDiscussions
-from .ml import DSSMLTask
+from .ml import DSSMLTask, DSSMLTaskQueues
 from .analysis import DSSAnalysis
 from .flow import DSSProjectFlow
 from .app import DSSAppManifest
@@ -593,12 +593,13 @@ class DSSProject(object):
 
     def list_mltask_queues(self):
         """
-        List all ML task queues in this project
+        List ML task queues in this project 
         
-        Returns:
-            the list of the ML task queues, each one as a JSON object
-        """
-        return self.client._perform_json("GET", "/projects/%s/models/lab/mltask-queues" % self.project_key)
+        :returns: a :class:`DSSMLTaskQueues` object containing a list of queues as dicts
+        :rtype: :class:`DSSMLTaskQueues`
+        """ 
+        ref = self.client._perform_json("GET", "/projects/%s/models/labs/mltask-queues" % self.project_key)
+        return DSSMLTaskQueues(ref["queues"])
 
     def create_analysis(self, input_dataset):
         """

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -593,10 +593,10 @@ class DSSProject(object):
 
     def list_mltask_queues(self):
         """
-        List all paused ML task queues in this project
+        List all ML task queues in this project
         
         Returns:
-            the list of the paused ML task queues, each one as a JSON object
+            the list of the ML task queues, each one as a JSON object
         """
         return self.client._perform_json("GET", "/projects/%s/models/lab/mltask-queues" % self.project_key)
 

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -593,13 +593,13 @@ class DSSProject(object):
 
     def list_mltask_queues(self):
         """
-        List ML task queues in this project 
+        List non-empty ML task queues in this project 
         
-        :returns: a :class:`DSSMLTaskQueues` object containing a list of queues as dicts
+        :returns: an iterable :class:`DSSMLTaskQueues` listing of MLTask queues (each a dict)
         :rtype: :class:`DSSMLTaskQueues`
         """ 
-        ref = self.client._perform_json("GET", "/projects/%s/models/labs/mltask-queues" % self.project_key)
-        return DSSMLTaskQueues(ref["queues"])
+        data = self.client._perform_json("GET", "/projects/%s/models/labs/mltask-queues" % self.project_key)
+        return DSSMLTaskQueues(data)
 
     def create_analysis(self, input_dataset):
         """

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -591,6 +591,14 @@ class DSSProject(object):
         """
         return DSSMLTask(self.client, self.project_key, analysis_id, mltask_id)
 
+    def list_mltask_queues(self):
+        """
+        List all paused ML task queues in this project
+        
+        Returns:
+            the list of the paused ML task queues, each one as a JSON object
+        """
+        return self.client._perform_json("GET", "/projects/%s/models/lab/mltask-queues" % self.project_key)
 
     def create_analysis(self, input_dataset):
         """


### PR DESCRIPTION
This PR adds two calls to the python API:
- `train_queue` - Starts running the queue of the ML task
- `list_mltask_queues` - Lists all the existing ML tasks in a project

[ch63630]