### PR TITLE
Fix set_license with utf-8 chars

### DIFF
--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -999,7 +999,7 @@ class DSSClient(object):
         :return: None
         """
         self._perform_empty(
-            "POST", "/admin/licensing/license", raw_body=license)
+            "POST", "/admin/licensing/license", body=json.loads(license))
 
 
     ########################################################


### PR DESCRIPTION
Using the json encoder manage for us the encoding/decoding on sender
receiver.

[[ch63983]](https://app.clubhouse.io/dataiku/story/63983/unable-to-set-license-via-api-if-it-contains-chinese-characters)