### PR TITLE
Chore/dss10 clarify get variable apis

### DIFF
--- a/dataikuapi/dss/admin.py
+++ b/dataikuapi/dss/admin.py
@@ -956,7 +956,7 @@ class DSSInstanceVariables(dict):
     """
 
     def __init__(self, client, variables):
-        super().__init__()
+        super(dict, self).__init__()
         self.update(variables)
         self.client = client
 

--- a/dataikuapi/dss/admin.py
+++ b/dataikuapi/dss/admin.py
@@ -950,9 +950,9 @@ class DSSClusterStatus(object):
 
 class DSSInstanceVariables(dict):
     """
-    Dict containing the instance variables. The variables can be modified directly in the dict and persisted using its `save` method.
+    Dict containing the instance variables. The variables can be modified directly in the dict and persisted using its :meth:`save` method.
 
-    Do not create this directly, use :meth:`dataikuapi.dssclient.DSSClient.get_global_variables`
+    Do not create this directly, use :meth:`dataikuapi.DSSClient.get_global_variables`
     """
 
     def __init__(self, client, variables):

--- a/dataikuapi/dss/admin.py
+++ b/dataikuapi/dss/admin.py
@@ -946,3 +946,24 @@ class DSSClusterStatus(object):
         Gets the whole status as a raw dictionary.
         """
         return self.status
+
+
+class DSSInstanceVariables(dict):
+    """
+    Dict containing the instance variables. The variables can be modified directly in the dict and persisted using its `save` method.
+
+    Do not create this directly, use :meth:`dataikuapi.dssclient.DSSClient.get_global_variables`
+    """
+
+    def __init__(self, client, variables):
+        super().__init__()
+        self.update(variables)
+        self.client = client
+
+    def save(self):
+        """
+        Save the changes made to the instance variables.
+
+        Note: this call requires an API key with admin rights.
+        """
+        return self.client._perform_empty("PUT", "/admin/variables/", body=self)

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -961,20 +961,6 @@ class DSSProject(object):
         return self.client._perform_json(
             "GET", "/projects/%s/variables/" % self.project_key)
 
-    def get_resolved_variables(self, typed=False):
-        """
-        Get a dictionary of resolved variables of this project.
-
-        :param bool typed: if True, the variable values will be typed in the returned dict, defaults to False
-        :returns: a dictionary with instance and project variables merged
-        """
-        return self.client._perform_json(
-            "GET",
-            "/projects/%s/variables-resolved" % self.project_key,
-            params={
-                "typed": "true" if typed else "false"
-            })
-
     def set_variables(self, obj):
         """
         Sets the variables of this project.

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -966,9 +966,7 @@ class DSSProject(object):
         Get a dictionary of resolved variables of this project.
 
         :param bool typed: if True, the variable values will be typed in the returned dict, defaults to False
-        :return: a dictionary with instance and project variables merged
-
-        :returns: a dictionary of the resolved project variables
+        :returns: a dictionary with instance and project variables merged
         """
         return self.client._perform_json(
             "GET",

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -961,6 +961,22 @@ class DSSProject(object):
         return self.client._perform_json(
             "GET", "/projects/%s/variables/" % self.project_key)
 
+    def get_resolved_variables(self, typed=False):
+        """
+        Get a dictionary of resolved variables of this project.
+
+        :param bool typed: if True, the variable values will be typed in the returned dict, defaults to False
+        :return: a dictionary with instance and project variables merged
+
+        :returns: a dictionary of the resolved project variables
+        """
+        return self.client._perform_json(
+            "GET",
+            "/projects/%s/variables-resolved" % self.project_key,
+            params={
+                "typed": "true" if typed else "false"
+            })
+
     def set_variables(self, obj):
         """
         Sets the variables of this project.

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -792,8 +792,7 @@ class DSSClient(object):
 
         """
         warnings.warn("set_variables is deprecated, please use get_global_variables().save()", DeprecationWarning)
-        return self._perform_empty(
-            "PUT", "/admin/variables/", body=variables)
+        return DSSInstanceVariables(self, variables).save()
 
 
     ########################################################

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -794,18 +794,18 @@ class DSSClient(object):
         warnings.warn("set_variables is deprecated, please use get_global_variables().save()", DeprecationWarning)
         return DSSInstanceVariables(self, variables).save()
 
-    def get_resolved_variables(self, projectKey=None, typed=False):
+    def get_resolved_variables(self, project_key=None, typed=False):
         """
         Get a dictionary of resolved variables of the project.
 
-        :param str projectKey: the project key, defaults to the current project if any
+        :param str project_key: the project key, defaults to the current project if any
         :param bool typed: if True, the variable values will be typed in the returned dict, defaults to False
         :returns: a dictionary with instance and project variables merged
         """
         import dataiku
         return self._perform_json(
             "GET",
-            "/projects/%s/variables-resolved" % (dataiku.default_project_key() if projectKey is None else projectKey),
+            "/projects/%s/variables-resolved" % (dataiku.default_project_key() if project_key is None else project_key),
             params={
                 "typed": "true" if typed else "false"
             })

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -794,6 +794,22 @@ class DSSClient(object):
         warnings.warn("set_variables is deprecated, please use get_global_variables().save()", DeprecationWarning)
         return DSSInstanceVariables(self, variables).save()
 
+    def get_resolved_variables(self, projectKey=None, typed=False):
+        """
+        Get a dictionary of resolved variables of the project.
+
+        :param str projectKey: the project key, defaults to the current project if any
+        :param bool typed: if True, the variable values will be typed in the returned dict, defaults to False
+        :returns: a dictionary with instance and project variables merged
+        """
+        import dataiku
+        return self._perform_json(
+            "GET",
+            "/projects/%s/variables-resolved" % (dataiku.default_project_key() if projectKey is None else projectKey),
+            params={
+                "typed": "true" if typed else "false"
+            })
+
 
     ########################################################
     # General settings

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -48,7 +48,7 @@ class DSSClient(object):
     ########################################################
     # Futures
     ########################################################
-            
+
     def list_futures(self, as_objects=False, all_users=False):
         """
         List the currently-running long tasks (a.k.a futures)
@@ -777,6 +777,24 @@ class DSSClient(object):
         return self._perform_json(
             "GET", "/admin/variables/")
 
+    def get_resolved_variables(self, project_key=None, typed=False):
+        """
+        Get a dictionary of resolved variables for a project.
+
+        :param str project_key: the project key, defaults to the current default project
+        :param bool typed: if True, the variable values will be typed in the returned dict, defaults to False
+        :return: a dictionary with instance and project variables merged
+
+        :returns: a Python dictionary of the resolved project variables
+        """
+        import dataiku
+        return self._perform_json(
+            "GET",
+            "/projects/%s/variables-resolved" % dataiku.default_project_key() if project_key is None else project_key,
+            params={
+                "typed": "true" if typed else "false"
+            })
+
     def set_variables(self, variables):
         """
         Updates the DSS instance's variables
@@ -952,7 +970,7 @@ class DSSClient(object):
         """
         return self._perform_json("POST", "/auth/info-from-browser-headers",
                 params={"withSecrets": with_secrets}, body=headers_dict)
-        
+
     def get_ticket_from_browser_headers(self, headers_dict):
          """
          Returns a ticket for the DSS user authenticated by the dictionary of

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -1,4 +1,4 @@
-import json
+import json, warnings
 
 from requests import Session
 from requests import exceptions
@@ -761,10 +761,17 @@ class DSSClient(object):
 
     def get_variables(self):
         """
+        Deprecated. Use get_global_variables
+        """
+        warnings.warn("get_variables is deprecated, please use get_global_variables", DeprecationWarning)
+        return self.get_global_variables()
+
+    def get_global_variables(self):
+        """
         Get the DSS instance's variables, as a Python dictionary
 
         This call requires an API key with admin rights
-        
+
         :returns: a Python dictionary of the instance-level variables
         """
         return self._perform_json(

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -10,7 +10,7 @@ from .dss.projectfolder import DSSProjectFolder
 from .dss.project import DSSProject
 from .dss.app import DSSApp
 from .dss.plugin import DSSPlugin
-from .dss.admin import DSSUser, DSSOwnUser, DSSGroup, DSSConnection, DSSGeneralSettings, DSSCodeEnv, DSSGlobalApiKey, DSSCluster
+from .dss.admin import DSSUser, DSSOwnUser, DSSGroup, DSSConnection, DSSGeneralSettings, DSSCodeEnv, DSSGlobalApiKey, DSSCluster, DSSInstanceVariables
 from .dss.meaning import DSSMeaning
 from .dss.sqlquery import DSSSQLQuery
 from .dss.discussion import DSSObjectDiscussions
@@ -772,10 +772,10 @@ class DSSClient(object):
 
         This call requires an API key with admin rights
 
-        :returns: a Python dictionary of the instance-level variables
+        :returns: A :class:`dataikuapi.dss.admin.DSSInstanceVariables` handle
         """
-        return self._perform_json(
-            "GET", "/admin/variables/")
+        variables = self._perform_json("GET", "/admin/variables/")
+        return DSSInstanceVariables(self, variables)
 
     def get_resolved_variables(self, project_key=None, typed=False):
         """
@@ -797,6 +797,8 @@ class DSSClient(object):
 
     def set_variables(self, variables):
         """
+        Deprecated. Use get_global_variables().save()
+
         Updates the DSS instance's variables
 
         This call requires an API key with admin rights
@@ -807,6 +809,7 @@ class DSSClient(object):
         :param dict variables: the new dictionary of all variables of the instance
 
         """
+        warnings.warn("set_variables is deprecated, please use get_global_variables().save()", DeprecationWarning)
         return self._perform_empty(
             "PUT", "/admin/variables/", body=variables)
 

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -777,24 +777,6 @@ class DSSClient(object):
         variables = self._perform_json("GET", "/admin/variables/")
         return DSSInstanceVariables(self, variables)
 
-    def get_resolved_variables(self, project_key=None, typed=False):
-        """
-        Get a dictionary of resolved variables for a project.
-
-        :param str project_key: the project key, defaults to the current default project
-        :param bool typed: if True, the variable values will be typed in the returned dict, defaults to False
-        :return: a dictionary with instance and project variables merged
-
-        :returns: a Python dictionary of the resolved project variables
-        """
-        import dataiku
-        return self._perform_json(
-            "GET",
-            "/projects/%s/variables-resolved" % dataiku.default_project_key() if project_key is None else project_key,
-            params={
-                "typed": "true" if typed else "false"
-            })
-
     def set_variables(self, variables):
         """
         Deprecated. Use get_global_variables().save()

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -761,7 +761,7 @@ class DSSClient(object):
 
     def get_variables(self):
         """
-        Deprecated. Use get_global_variables
+        Deprecated. Use :meth:`get_global_variables`
         """
         warnings.warn("get_variables is deprecated, please use get_global_variables", DeprecationWarning)
         return self.get_global_variables()
@@ -779,7 +779,7 @@ class DSSClient(object):
 
     def set_variables(self, variables):
         """
-        Deprecated. Use get_global_variables().save()
+        Deprecated. Use :meth:`get_global_variables` and :meth:`dataikuapi.dss.admin.DSSInstanceVariables.save`
 
         Updates the DSS instance's variables
 


### PR DESCRIPTION
Clarify the `get_*variables` apis:
- rename `dataikuapi.dssclient.DSSClient.get_variables` to `dataikuapi.dssclient.DSSClient.get_global_variables` to clarify its intention
- recreate `dataikuapi.dssclient.DSSClient.get_variables` as a proxy to `dataikuapi.dssclient.DSSClient.get_global_variables` and deprecate it to inform users they should use the new method
- add `dataikuapi.dssclient.DSSClient.get_resolved_variables` mimicing `dataiku.get_custom_variables` to get access to resolved variables without admin permissions

[ch64060]