### PR TITLE
[sc-76604] Fix FM API for azure

### DIFF
--- a/dataikuapi/fm/instances.py
+++ b/dataikuapi/fm/instances.py
@@ -144,7 +144,7 @@ class FMAWSInstanceCreator(FMInstanceCreator):
         return FMAWSInstance(self.client, instance)
 
 
-class (FMInstanceCreator):
+class FMAzureInstanceCreator(FMInstanceCreator):
     def create(self):
         """
         Create the DSS instance

--- a/dataikuapi/fm/instances.py
+++ b/dataikuapi/fm/instances.py
@@ -86,8 +86,8 @@ class FMInstanceCreator(object):
         self.data["dataVolumeSizeGB"] = data_volume_size
         self.data["dataVolumeSizeMaxGB"] = data_volume_size_max
         self.data["dataVolumeIOPS"] = data_volume_IOPS
-        self.data["dataVolumeEncryption"] = data_volume_encryption.value
-        self.data["dataVolumeEncryptionKey"] = data_volume_encryption_key
+        self.data["volumesEncryption"] = data_volume_encryption.value
+        self.data["volumesEncryptionKey"] = data_volume_encryption_key
         return self
 
     def with_cloud_tags(self, cloud_tags):
@@ -144,7 +144,7 @@ class FMAWSInstanceCreator(FMInstanceCreator):
         return FMAWSInstance(self.client, instance)
 
 
-class FMAzureInstanceCreator(FMInstanceCreator):
+class (FMInstanceCreator):
     def create(self):
         """
         Create the DSS instance

--- a/dataikuapi/fmclient.py
+++ b/dataikuapi/fmclient.py
@@ -372,7 +372,7 @@ class FMClientAzure(FMClient):
         :param str host: Full url of the FM
         """
         self.cloud = "Azure"
-        super(FMClientAWS, self).__init__(
+        super(FMClientAzure, self).__init__(
             host, api_key_id, api_key_secret, tenant_id, extra_headers
         )
 


### PR DESCRIPTION
As I was testing the API against Azure, I found another issue around the volumes encryption. Nothin very hard to fix at the end, just the mapping of the model was incorrect.

Note that is is targeted for 10.0.1 for now

# For testing

```
./fmadmin create-personal-api-key admin fm-api-key.txt
```

Then in a DSS notebook _(for simplicity but it make no sense to provision stuff from DSS, its just easier to use the python API from there. Good enough for testing it)_

```
import dataiku
from dataiku import pandasutils as pdu
import pandas as pd
import dataikuapi

client = dataikuapi.FMClientAzure(host="http://localhost:10000", api_key_id="XXX", api_key_secret="XXX")
client.list_instances()
network = client.new_virtual_network_creator("test").with_azure_virtual_network("/subscriptions/8c59bf15-b4a9-4398-a354-d2a4e7d60e2a/resourceGroups/qcastel-fm/providers/Microsoft.Network/virtualNetworks/qcastel-fm-vn", "qcastel-fm-subnet").create()
instance_template = client.new_instance_template_creator("test").create()
image = client.list_instance_images()[0]
instance_creator = client.new_instance_creator("test", instance_template.id, network.id, image['id']).with_dss_node_type("design").with_cloud_instance_type("Standard_B8ms").with_data_volume_options(data_volume_type="StandardSSD_LRS", data_volume_size=1000, data_volume_encryption=dataikuapi.fm.instances.FMInstanceEncryptionMode.DEFAULT_KEY)
print(instance_creator.data)
instance = instance_creator.create()
instance.reprovision()
```