### PR TITLE
Give MLflowHandle the ability to reload artifact_repository_registry

### DIFF
--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -1,4 +1,7 @@
 import time, warnings, sys, os.path as osp
+
+from ..dss_plugin_mlflow import MLflowHandle
+
 from .dataset import DSSDataset, DSSDatasetListItem, DSSManagedDatasetCreationHelper
 from .modelcomparison import DSSModelComparison
 from .jupyternotebook import DSSJupyterNotebook, DSSJupyterNotebookListItem
@@ -21,7 +24,6 @@ from .ml import DSSMLTask, DSSMLTaskQueues
 from .analysis import DSSAnalysis
 from .flow import DSSProjectFlow
 from .app import DSSAppManifest
-from .dss_plugin_mlflow import MLflowHandle
 
 
 class DSSProject(object):

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -21,6 +21,7 @@ from .ml import DSSMLTask, DSSMLTaskQueues
 from .analysis import DSSAnalysis
 from .flow import DSSProjectFlow
 from .app import DSSAppManifest
+from .dss_plugin_mlflow import MLflowHandle
 
 
 class DSSProject(object):
@@ -1594,6 +1595,18 @@ class DSSProject(object):
     def get_app_manifest(self):
         raw_data = self.client._perform_json("GET", "/projects/%s/app-manifest" % self.project_key)
         return DSSAppManifest(self.client, raw_data, self.project_key)
+
+    ########################################################
+    # MLflow
+    ########################################################
+    def setup_mlflow(self, managed_folder="mlflow_artifacts", host=None):
+        """
+        Setup the dss-plugin for MLflow
+
+        :param str managed_folder: managed folder where artifacts are stored
+        :param str host: setup a custom host if the backend used is not DSS
+        """
+        return MLflowHandle(client=self.client, project_key=self.project_key, managed_folder=managed_folder, host=host)
 
 
 class TablesImportDefinition(object):

--- a/dataikuapi/dss_plugin_mlflow/utils.py
+++ b/dataikuapi/dss_plugin_mlflow/utils.py
@@ -38,11 +38,9 @@ class MLflowHandle:
         sys.path.insert(0, self.tempdir)
 
         # Reload the artifact_repository_registry in case MLflow was imported beforehand
-        import mlflow
-        try:  # python 3.4+
+        if sys.version_info > (3, 4):
             from importlib import reload
-        except ImportError:
-            pass
+        import mlflow
         reload(mlflow.store.artifact.artifact_repository_registry)
 
         # Setup authentication

--- a/dataikuapi/dss_plugin_mlflow/utils.py
+++ b/dataikuapi/dss_plugin_mlflow/utils.py
@@ -37,6 +37,14 @@ class MLflowHandle:
             )
         sys.path.insert(0, self.tempdir)
 
+        # Reload the artifact_repository_registry in case MLflow was imported beforehand
+        import mlflow
+        try:  # python 3.4+
+            from importlib import reload
+        except ImportError:
+            pass
+        reload(mlflow.store.artifact.artifact_repository_registry)
+
         # Setup authentication
         if client._session.auth is not None:
             self.mlflow_env.update({

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -5,7 +5,6 @@ from requests import exceptions
 from requests.auth import HTTPBasicAuth
 
 from dataikuapi.dss.notebook import DSSNotebook
-from .dss_plugin_mlflow import MLflowHandle
 from .dss.future import DSSFuture
 from .dss.projectfolder import DSSProjectFolder
 from .dss.project import DSSProject
@@ -1087,19 +1086,6 @@ class DSSClient(object):
         :rtype: :class:`dataikuapi.discussion.DSSObjectDiscussions`
         """
         return DSSObjectDiscussions(self, project_key, object_type, object_id)
-
-    ########################################################
-    # MLflow
-    ########################################################
-    def setup_mlflow(self, project_key, managed_folder="mlflow_artifacts", host=None):
-        """
-        Setup the dss-plugin for MLflow
-
-        :param str project_key: identifier of the project to access
-        :param str managed_folder: managed folder where artifacts are stored
-        :param str host: setup a custom host if the backend used is not DSS
-        """
-        return MLflowHandle(client=self, project_key=project_key, managed_folder=managed_folder, host=host)
 
 
 class TemporaryImportHandle(object):


### PR DESCRIPTION
On `feature/mlflow-experiment-tracking` this code will fail:

```python
from dataikuapi import DSSClient
import mlflow
import tempfile

client = DSSClient("http://localhost:8082", apiKey)
project = client.get_project("DEMOMLFLOW")

with client.setup_mlflow(project.project_key):
	mlflow.log_artifact(tempfile.mkstemp()[1])
```

with:

```shell
~/devmisc/mlflow/mlflow/store/artifact/artifact_repository_registry.py in get_artifact_repository(self, artifact_uri)
     68                 "Could not find a registered artifact repository for: {}. "
     69                 "Currently registered schemes are: {}".format(
---> 70                     artifact_uri, list(self._registry.keys())
     71                 )
     72             )

MlflowException: Could not find a registered artifact repository for: dss-managed-folder:////0/MC8q69UY/artifacts. Currently registered schemes are: ['', 'file', 's3', 'gs', 'wasbs', 'ftp', 'sftp', 'dbfs', 'hdfs', 'viewfs', 'runs', 'models', 'http', 'https']
```


This is because `import mlflow` will register artifacts repositories, including those from plugins, at import. However, we register our `PluginDSSManagedFolderArtifactRepository` in the `setup_client` so after the import of MLflow in this example. 
Hence this PR add the ability for `setup_client` to reload `mlflow.store.artifact.artifact_repository_registry` module. The try excepts handles python2 and 3 (`reload` is a builtin in python2).

The above example should work out of the box on this branch.

Companion DIP branch: https://github.com/dataiku/dip/pull/14636