### PR TITLE
Deploy anywhere feature

### DIFF
--- a/dataikuapi/apinode_admin_client.py
+++ b/dataikuapi/apinode_admin_client.py
@@ -36,3 +36,9 @@ class APINodeAdminClient(DSSBaseClient):
 
     def get_metrics(self):
         return self._perform_json("GET", "metrics")
+
+    def create_code_env(self, file_dir, language):
+        self._perform_empty("POST", "codeenvs", params={
+            "fileDir": file_dir,
+            "language": language
+        })

--- a/dataikuapi/apinode_admin_client.py
+++ b/dataikuapi/apinode_admin_client.py
@@ -37,8 +37,8 @@ class APINodeAdminClient(DSSBaseClient):
     def get_metrics(self):
         return self._perform_json("GET", "metrics")
 
-    def create_code_env(self, file_dir, language):
-        self._perform_empty("POST", "codeenvs", params={
+    def import_code_env_in_cache(self, file_dir, language):
+        self._perform_empty("POST", "cached-code-envs", params={
             "fileDir": file_dir,
             "language": language
         })


### PR DESCRIPTION
Python API part of the deploy anywhere feature: https://github.com/dataiku/dip/pull/14733
Adds a handler to the API node admin client to create code envs in the global cache of an API node.

See [ch75547](https://app.shortcut.com/dataiku/story/75547/base-docker-image-for-vertex-ai-prediction).