### PR TITLE
Set get_scoring_python_stream

### DIFF
--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -2658,6 +2658,24 @@ class DSSTrainedPredictionModelDetails(DSSTrainedModelDetails):
                 "GET", "/projects/%s/savedmodels/%s/versions/%s/scoring-pmml" %
                 (self.saved_model.project_key, self.saved_model.sm_id, self.saved_model_version))
 
+    def get_scoring_python_stream(self):
+        """
+        Get a zip containing data to use Python scoring for this trained model,
+        provided that you have the license to do so and that the model is compatible with Python scoring
+        You need to close the stream after download. Failure to do so will result in the DSSClient becoming unusable.
+
+        :returns: an archive file, as a stream
+        :rtype: file-like
+        """
+        if self.mltask is not None:
+            return self.mltask.client._perform_raw(
+                "GET", "/projects/%s/models/lab/%s/%s/models/%s/scoring-python" %
+                (self.mltask.project_key, self.mltask.analysis_id, self.mltask.mltask_id, self.mltask_model_id))
+        else:
+            return self.saved_model.client._perform_raw(
+                "GET", "/projects/%s/savedmodels/%s/versions/%s/scoring-python" %
+                (self.saved_model.project_key, self.saved_model.sm_id, self.saved_model_version))
+
 
     ## Post-train computations
 

--- a/dataikuapi/dss/ml.py
+++ b/dataikuapi/dss/ml.py
@@ -2676,6 +2676,13 @@ class DSSTrainedPredictionModelDetails(DSSTrainedModelDetails):
                 "GET", "/projects/%s/savedmodels/%s/versions/%s/scoring-python" %
                 (self.saved_model.project_key, self.saved_model.sm_id, self.saved_model_version))
 
+    def get_scoring_python(self, filename):
+        """
+        Download the zip containing data to use Python scoring for this trained model in filename,
+        provided that you have the license to do so and that the model is compatible with Python scoring
+        """
+        with open(filename, "wb") as f:
+            f.write(self.get_scoring_python_stream().content)
 
     ## Post-train computations
 


### PR DESCRIPTION
Companion dip PR https://github.com/dataiku/dip/pull/14999

```python
from dataikuapi import DSSClient
from sklearn import datasets
from sklearn import svm
import json

host = "http://localhost:8082/"
api_key = "kXxMvwMRvU2KoVqpCH47e0eoJ3GlJXWI"
project_key = "LOL"

client = DSSClient(host, api_key)
project = client.get_project(project_key)
task = project.get_ml_task("ptkvqn3M", "U1eqYF52")
trained_model = task.get_trained_model_details("A-LOL-ptkvqn3M-U1eqYF52-s2-pp1-m1")
response = trained_model.get_scoring_python_stream()

with open("~/Downloads/test.zip", "wb") as f:
    f.write(response.content)

response = trained_model.get_scoring_python("~/Downloads/test_no_stream.zip")
```