### PR TITLE
Feature store public API

### DIFF
--- a/dataikuapi/dss/dataset.py
+++ b/dataikuapi/dss/dataset.py
@@ -741,7 +741,6 @@ class DSSDatasetSettings(DSSTaggableObjectSettings):
     def is_feature_group(self):
         """
         Indicates whether the Dataset is defined as a Feature Group, available in the Feature Store.
-        Changes of this property will be applied when calling :meth:`save` and require the "Manage Feature Store" permission.
 
         :rtype: bool
         """
@@ -749,7 +748,7 @@ class DSSDatasetSettings(DSSTaggableObjectSettings):
 
     def set_feature_group(self, status):
         """
-        Indicates whether the Dataset is defined as a Feature Group, available in the Feature Store.
+        (Un)sets the dataset as a Feature Group, available in the Feature Store.
         Changes of this property will be applied when calling :meth:`save` and require the "Manage Feature Store" permission.
 
         :param status: whether the dataset should be defined as a feature group

--- a/dataikuapi/dss/dataset.py
+++ b/dataikuapi/dss/dataset.py
@@ -737,6 +737,26 @@ class DSSDatasetSettings(DSSTaggableObjectSettings):
     def add_raw_schema_column(self, column):
         self.settings["schema"]["columns"].append(column)
 
+    @property
+    def is_feature_group(self):
+        """
+        Indicates whether the Dataset is defined as a Feature Group, available in the Feature Store.
+        Changes of this property will be applied when calling :meth:`save` and require the "Manage Feature Store" permission.
+
+        :rtype: bool
+        """
+        return self.settings["featureGroup"]
+
+    def set_feature_group(self, status):
+        """
+        Indicates whether the Dataset is defined as a Feature Group, available in the Feature Store.
+        Changes of this property will be applied when calling :meth:`save` and require the "Manage Feature Store" permission.
+
+        :param status: whether the dataset should be defined as a feature group
+        :type status: bool
+        """
+        self.settings["featureGroup"] = status
+
     def save(self):
         self.dataset.client._perform_empty(
                 "PUT", "/projects/%s/datasets/%s" % (self.dataset.project_key, self.dataset.dataset_name),

--- a/dataikuapi/dss/feature_store.py
+++ b/dataikuapi/dss/feature_store.py
@@ -12,6 +12,10 @@ class DSSFeatureGroupListItem(object):
         return self.project_key + "." + self.name
 
     def get_as_dataset(self):
+        """
+        :return: a handle on the dataset
+        :rtype: :class:`dataikuapi.dss.dataset.DSSDataset`
+        """
         return DSSDataset(self.client, self.project_key, self.name)
 
 
@@ -29,7 +33,7 @@ class DSSFeatureStore(object):
         and that are defined as feature groups in the DSS instance
 
         :return: list of dataset names
-        :rtype: list of str
+        :rtype: list of :class:`dataikuapi.feature_store.DSSFeatureGroupListItem`
         """
         items = self.client._perform_json("GET", "/feature-store/feature-groups")
         return [DSSFeatureGroupListItem(self.client, item["projectKey"], item["name"]) for item in items]

--- a/dataikuapi/dss/feature_store.py
+++ b/dataikuapi/dss/feature_store.py
@@ -1,3 +1,20 @@
+from dataikuapi.dss.dataset import DSSDataset
+
+
+class DSSFeatureGroupListItem(object):
+    def __init__(self, client, project_key, name):
+        self.client = client
+        self.project_key = project_key
+        self.name = name
+
+    @property
+    def id(self):
+        return self.project_key + "." + self.name
+
+    def get_as_dataset(self):
+        return DSSDataset(self.client, self.project_key, self.name)
+
+
 class DSSFeatureStore(object):
     def __init__(self, client):
         """
@@ -14,4 +31,5 @@ class DSSFeatureStore(object):
         :return: list of dataset names
         :rtype: list of str
         """
-        return self.client._perform_json("GET", "/feature-store/feature-groups/list")
+        items = self.client._perform_json("GET", "/feature-store/feature-groups")
+        return [DSSFeatureGroupListItem(self.client, item["projectKey"], item["name"]) for item in items]

--- a/dataikuapi/dss/feature_store.py
+++ b/dataikuapi/dss/feature_store.py
@@ -1,14 +1,17 @@
 class DSSFeatureStore(object):
     def __init__(self, client):
         """
-        A handle on the Feature Store. Do not call this methid directly, call """
+        A handle on the Feature Store.
+        Do not create this class directly, use :meth:`DSSClient.get_feature_store`
+        """
         self.client = client
 
     def list_feature_groups(self):
         """
-        Get a list of names of datasets defined as feature groups on the DSS instance.
+        Get a list of names of datasets on which the user has right permissions
+        and that are defined as feature groups in the DSS instance
 
-        :return: list of names of datasets defined as feature groups
+        :return: list of dataset names
         :rtype: list of str
         """
         return self.client._perform_json("GET", "/feature-store/feature-groups/list")

--- a/dataikuapi/dss/feature_store.py
+++ b/dataikuapi/dss/feature_store.py
@@ -13,6 +13,8 @@ class DSSFeatureGroupListItem(object):
 
     def get_as_dataset(self):
         """
+        Gets the feature group as a dataset
+
         :return: a handle on the dataset
         :rtype: :class:`dataikuapi.dss.dataset.DSSDataset`
         """
@@ -29,10 +31,9 @@ class DSSFeatureStore(object):
 
     def list_feature_groups(self):
         """
-        Get a list of names of datasets on which the user has right permissions
-        and that are defined as feature groups in the DSS instance
+        Get a list of feature groups on which the user has at least read permissions
 
-        :return: list of dataset names
+        :return: list of feature groups
         :rtype: list of :class:`dataikuapi.feature_store.DSSFeatureGroupListItem`
         """
         items = self.client._perform_json("GET", "/feature-store/feature-groups")

--- a/dataikuapi/dss/feature_store.py
+++ b/dataikuapi/dss/feature_store.py
@@ -1,0 +1,14 @@
+class DSSFeatureStore(object):
+    def __init__(self, client):
+        """
+        A handle on the Feature Store. Do not call this methid directly, call """
+        self.client = client
+
+    def list_feature_groups(self):
+        """
+        Get a list of names of datasets defined as feature groups on the DSS instance.
+
+        :return: list of names of datasets defined as feature groups
+        :rtype: list of str
+        """
+        return self.client._perform_json("GET", "/feature-store/feature-groups/list")

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -4,6 +4,7 @@ from requests import Session
 from requests import exceptions
 from requests.auth import HTTPBasicAuth
 
+from .dss.feature_store import DSSFeatureStore
 from .dss.notebook import DSSNotebook
 from .dss.future import DSSFuture
 from .dss.projectfolder import DSSProjectFolder
@@ -1117,6 +1118,14 @@ class DSSClient(object):
         :rtype: :class:`dataikuapi.discussion.DSSObjectDiscussions`
         """
         return DSSObjectDiscussions(self, project_key, object_type, object_id)
+
+    ########################################################
+    # Feature Store
+    ########################################################
+    def get_feature_store(self):
+        return DSSFeatureStore(self)
+
+
 
 class TemporaryImportHandle(object):
     def __init__(self, client, import_id):

--- a/dataikuapi/dssclient.py
+++ b/dataikuapi/dssclient.py
@@ -1123,8 +1123,13 @@ class DSSClient(object):
     # Feature Store
     ########################################################
     def get_feature_store(self):
-        return DSSFeatureStore(self)
+        """
+        Get a handle to interact with the Feature Store.
 
+        :return: a handle on the feature store
+        :rtype: :class:`dataikuapi.feature_store.DSSFeatureStore`
+        """
+        return DSSFeatureStore(self)
 
 
 class TemporaryImportHandle(object):


### PR DESCRIPTION
Companion dip PR: https://github.com/dataiku/dip/pull/15317

This PR adds the public python API of the feature store.

It introduces a `DSSFeatureStore` class, than can be instantiated through the api client, whose unique method allows to list feature groups.

It also add a read property and a method to `DSSDatasetSettings` to check if a dataset is a feature group and to promote (or downgrade) a dataset to the quality of feature group.