### PR TITLE
Dont auto create managed folder in setup_mlflow

### DIFF
--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -764,6 +764,23 @@ class DSSProject(object):
         """
         return DSSManagedFolder(self.client, self.project_key, odb_id)
 
+    def find_managed_folder_by_name(self, name):
+        """
+        Get a list of managed folders matching the 'name' parameter.
+
+        Args:
+            name: the managed folder name to look for
+
+        Returns:
+            A list of :class:`dataikuapi.dss.managedfolder.DSSManagedFolder` managed folder handles.
+            Can be empty if there is no managed folder matching this name.
+        """
+        managed_folders = [
+            x["id"] for x in self.list_managed_folders()
+            if x["name"] == name
+        ]
+        return [DSSManagedFolder(self.client, self.project_key, managed_folder) for managed_folder in managed_folders]
+
     def create_managed_folder(self, name, folder_type=None, connection_name="filesystem_folders"):
         """
         Create a new managed folder in the project, and return a handle to interact with it

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -764,23 +764,6 @@ class DSSProject(object):
         """
         return DSSManagedFolder(self.client, self.project_key, odb_id)
 
-    def find_managed_folder_by_name(self, name):
-        """
-        Get a list of managed folders matching the 'name' parameter.
-
-        Args:
-            name: the managed folder name to look for
-
-        Returns:
-            A list of :class:`dataikuapi.dss.managedfolder.DSSManagedFolder` managed folder handles.
-            Can be empty if there is no managed folder matching this name.
-        """
-        managed_folders = [
-            x["id"] for x in self.list_managed_folders()
-            if x["name"] == name
-        ]
-        return [DSSManagedFolder(self.client, self.project_key, managed_folder) for managed_folder in managed_folders]
-
     def create_managed_folder(self, name, folder_type=None, connection_name="filesystem_folders"):
         """
         Create a new managed folder in the project, and return a handle to interact with it

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -1,4 +1,4 @@
-import time, warnings, sys, os.path as osp
+import warnings, os.path as osp
 
 from ..dss_plugin_mlflow import MLflowHandle
 
@@ -1629,8 +1629,7 @@ class DSSProject(object):
         """
         Setup the dss-plugin for MLflow
 
-        :param managed_folder: Managed folder where artifacts should be stored.
-                               Either a managed folder id, or an instance of :class:`dataikuapi.dss.DSSManagedFolder`.
+        :param object managed_folder: a :class:`dataikuapi.dss.DSSManagedFolder` where MLflow artifacts should be stored.
         :param str host: setup a custom host if the backend used is not DSS
         """
         return MLflowHandle(client=self.client, project=self, managed_folder=managed_folder, host=host)

--- a/dataikuapi/dss/project.py
+++ b/dataikuapi/dss/project.py
@@ -1625,14 +1625,15 @@ class DSSProject(object):
 
     # MLflow experiment tracking
     ########################################################
-    def setup_mlflow(self, managed_folder_name="mlflow_artifacts", host=None):
+    def setup_mlflow(self, managed_folder, host=None):
         """
         Setup the dss-plugin for MLflow
 
-        :param str managed_folder_name: name of the managed folder where artifacts should be stored
+        :param managed_folder: Managed folder where artifacts should be stored.
+                               Either a managed folder id, or an instance of :class:`dataikuapi.dss.DSSManagedFolder`.
         :param str host: setup a custom host if the backend used is not DSS
         """
-        return MLflowHandle(client=self.client, project_key=self.project_key, managed_folder_name=managed_folder_name, host=host)
+        return MLflowHandle(client=self.client, project=self, managed_folder=managed_folder, host=host)
 
     def get_mlflow_extension(self):
         """

--- a/dataikuapi/dss_plugin_mlflow/utils.py
+++ b/dataikuapi/dss_plugin_mlflow/utils.py
@@ -1,3 +1,6 @@
+from ..dss.utils import AnyLoc
+from ..utils import DataikuException
+import logging
 import os
 import sys
 import tempfile
@@ -6,7 +9,7 @@ from base64 import b64encode
 
 
 class MLflowHandle:
-    def __init__(self, client, project_key, managed_folder_name, host=None):
+    def __init__(self, client, project, managed_folder, host=None):
         """ Add the MLflow-plugin parts of dataikuapi to MLflow local setup.
 
         This method deals with
@@ -19,7 +22,8 @@ class MLflowHandle:
         with DSS backend as the tracking backend and enable using DSS managed folder
         as artifact location.
         """
-        self.project_key = project_key
+        self.project = project
+        self.project_key = project.project_key
         self.client = client
         self.mlflow_env = {}
 
@@ -57,32 +61,28 @@ class MLflowHandle:
                 "DSS_MLFLOW_TOKEN": self.client.internal_ticket,
                 "DSS_MLFLOW_INTERNAL_TICKET": self.client.internal_ticket
             })
-        # Set host, tracking URI and project key
+
+        def full_id(mf):
+            return mf.project.project_key + "." + mf.id
+
+        def get_managed_folder(smart_mf_id):
+            return client.get_project(smart_mf_id.project_key).get_managed_folder(smart_mf_id.object_id)
+
+        mf_id = managed_folder if isinstance(managed_folder, str) else full_id(managed_folder)
+        smart_mf_id = AnyLoc.from_ref(self.project_key, mf_id)
+        try:
+            get_managed_folder(smart_mf_id).get_definition()
+        except DataikuException as e:
+            if "NotFoundException" in str(e):
+                logging.error('The managed folder "%s" does not exist, please create it in your project flow before running this command.' % (mf_id))
+            raise
+
+        # Set host, tracking URI, project key and managed_folder_id
         self.mlflow_env.update({
-            "DSS_MLFLOW_PROJECTKEY": project_key,
+            "DSS_MLFLOW_PROJECTKEY": self.project_key,
             "MLFLOW_TRACKING_URI": self.client.host + "/dip/publicapi" if host is None else host,
-            "DSS_MLFLOW_HOST": self.client.host
-        })
-
-        # Get or create managed folder with name 'managed_folder_name'
-        project = self.client.get_project(project_key)
-        managed_folders = [
-            x["id"] for x in project.list_managed_folders()
-            if x["name"] == managed_folder_name
-        ]
-        managed_folder = None
-        if len(managed_folders) > 0:
-            managed_folder = project.get_managed_folder(managed_folders[0])
-        else:
-            managed_folder = project.create_managed_folder(managed_folder_name)
-
-
-        # TODO: don't allow to pass a managed folder name, everything is already
-        # wired in artifact_repository and in the backend for DSS_MLFLOW_MANAGED_FOLDER_ID to contain
-        # a smart ref. So, instead of managed_folder_name, we should take a DSSManagedFolder
-        # or a managed folder id/smart ref and set DSS_MLFLOW_MANAGED_FOLDER_ID to that (smart) id.
-        self.mlflow_env.update({
-            "DSS_MLFLOW_MANAGED_FOLDER_ID": managed_folder.id
+            "DSS_MLFLOW_HOST": self.client.host,
+            "DSS_MLFLOW_MANAGED_FOLDER_ID": mf_id
         })
 
         os.environ.update(self.mlflow_env)


### PR DESCRIPTION
Stop creating managed folder automatically in setup_mlflow.

Tested manually and by running the integration/python/scenario/ml/prediction/mlflow/experiment_tracking/test_autolog.py test.

Related to:
- https://github.com/dataiku/dip/pull/15360
- https://github.com/dataiku/dku-contrib-private/pull/151