### PR TITLE
client for FM on GCP

### DIFF
--- a/dataikuapi/__init__.py
+++ b/dataikuapi/__init__.py
@@ -1,5 +1,5 @@
 from .dssclient import DSSClient
-from .fmclient import FMClientAWS, FMClientAzure
+from .fmclient import FMClientAWS, FMClientAzure, FMClientGCP
 
 from .apinode_client import APINodeClient
 from .apinode_admin_client import APINodeAdminClient

--- a/dataikuapi/fm/instances.py
+++ b/dataikuapi/fm/instances.py
@@ -158,6 +158,20 @@ class FMAzureInstanceCreator(FMInstanceCreator):
         return FMAzureInstance(self.client, instance)
 
 
+class FMGCPInstanceCreator(FMInstanceCreator):
+    def create(self):
+        """
+        Create the DSS instance
+
+        :return: Created DSS Instance
+        :rtype: :class:`dataikuapi.fm.instances.FMGCPInstance`
+        """
+        instance = self.client._perform_tenant_json(
+            "POST", "/instances", body=self.data
+        )
+        return FMGCPInstance(self.client, instance)
+
+
 class FMInstance(object):
     """
     A handle to interact with a DSS instance.
@@ -360,6 +374,19 @@ class FMAzureInstance(FMInstance):
         """
         self.instance_data["azureAssignElasticIP"] = enable
         self.instance_data["azurePublicIPId"] = public_ip_id
+        return self
+
+
+class FMGCPInstance(FMInstance):
+    def set_public_ip(self, enable, public_ip_id):
+        """
+        Set a public ip for this instance
+
+        :param boolan enable: Enable the public ip allocation
+        :param str public_ip_id: GCP Public IP ID
+        """
+        self.instance_data["gcpAssignPublicIP"] = enable
+        self.instance_data["gcpPublicIPId"] = public_ip_id
         return self
 
 

--- a/dataikuapi/fm/instancesettingstemplates.py
+++ b/dataikuapi/fm/instancesettingstemplates.py
@@ -198,6 +198,45 @@ class FMAzureInstanceSettingsTemplateCreator(FMInstanceSettingsTemplateCreator):
         return self
 
 
+class FMGCPInstanceSettingsTemplateCreator(FMInstanceSettingsTemplateCreator):
+    def with_ssh_key(self, ssh_public_key):
+        """
+        Add an SSH public key to the DSS Instance.
+        Needed to access it through SSH, using the centos user.
+
+        :param str ssh_public_key: The content of the public key to add to the instance.
+        """
+        self.data["gcpSshKey"] = ssh_public_key
+        return self
+
+    def with_restrict_metadata_server_access(self, restrict_metadata_server_access=True):
+        """
+        Restrict GCloud metadata server access on the DSS instance.
+
+        :param boolean restrict_metadata_server_access: Optional, If true, restrict the access to the metadata server access. Defaults to true
+        """
+        self.data["restrictGcpMetadataServerAccess"] = restrict_metadata_server_access
+        return self
+
+    def with_block_project_wide_keys(self, block_project_wide_keys=True):
+        """
+        Restrict GCloud metadata server access on the DSS instance.
+
+        :param boolean block_project_wide_keys: Optional, If true, block project-wide ssh keys on the instance. Defaults to true
+        """
+        self.data["gcpBlockProjectWideKeys"] = block_project_wide_keys
+        return self
+
+    def with_runtime_service_account(self, startup_service_account):
+        """
+        Add a service account to be assigned to the DSS instance on startup
+
+        :param str startup_service_account: service account email
+        """
+        self.data["startupServiceAccount"] = startup_service_account
+        return self
+
+
 class FMInstanceSettingsTemplate(object):
     def __init__(self, client, ist_data):
         self.client = client

--- a/dataikuapi/fm/tenant.py
+++ b/dataikuapi/fm/tenant.py
@@ -146,3 +146,18 @@ class FMCloudAuthentication(dict):
         }
 
         return FMCloudAuthentication(data)
+
+    @staticmethod
+    def gcp(project_id, service_account_key):
+        """
+        Azure Only
+
+        :param str project_id: GCP project
+        :param str service_account_key: Optional, service account key (JSON)
+        """
+        data = {
+            "gcpProjectId": project_id,
+            "gcpServiceAccountKey": service_account_key
+        }
+
+        return FMCloudAuthentication(data)

--- a/dataikuapi/fm/tenant.py
+++ b/dataikuapi/fm/tenant.py
@@ -150,7 +150,7 @@ class FMCloudAuthentication(dict):
     @staticmethod
     def gcp(project_id, service_account_key):
         """
-        Azure Only
+        GCP Only
 
         :param str project_id: GCP project
         :param str service_account_key: Optional, service account key (JSON)

--- a/dataikuapi/fm/virtualnetworks.py
+++ b/dataikuapi/fm/virtualnetworks.py
@@ -261,7 +261,7 @@ class FMGCPVirtualNetwork(FMVirtualNetwork):
             self.vn_data["gcpAssignPublicIP"] = public_ip
         return self
 
-    def set_location_for_created_resources(self, project_id=None,zone=None):
+    def set_location_for_created_resources(self, project_id=None, zone=None):
         """
         Set the location in GCP of the instances created using this virtual network
 

--- a/dataikuapi/fm/virtualnetworks.py
+++ b/dataikuapi/fm/virtualnetworks.py
@@ -110,6 +110,42 @@ class FMAzureVirtualNetworkCreator(FMVirtualNetworkCreator):
         return FMAzureVirtualNetwork(self.client, vn)
 
 
+class FMGCPVirtualNetworkCreator(FMVirtualNetworkCreator):
+    def with_vpc(self, project_id, network, subnetwork):
+        """
+        Setup the VPC which the virtual network will use
+
+        :param str project_id: ID of the project in which the network is defined
+        :param str network: name of the network
+        :param str subnetwork: name of the subnetwork
+        """
+        self.data["gcpProjectId"] = project_id
+        self.data["gcpNetwork"] = network
+        self.data["gcpSubnetwork"] = subnetwork
+        return self
+
+    def with_network_tags(self, *network_tags):
+        """
+        Use network tags on the instances created in the virtual network
+
+        :param str *network_tags: network tags to assign to the instances created in this virtual network.
+        """
+        self.data["gcpNetworkTags"] = network_tags
+        return self
+
+    def create(self):
+        """
+        Create the virtual network
+
+        :return: Created virtual network
+        :rtype: :class:`dataikuapi.fm.virtualnetworks.FMGCPVirtualNetwork`
+        """
+        vn = self.client._perform_tenant_json(
+            "POST", "/virtual-networks", body=self.data, params={ 'useDefaultValues':self.use_default_values }
+        )
+        return FMGCPVirtualNetwork(self.client, vn)
+
+
 class FMVirtualNetwork(object):
     def __init__(self, client, vn_data):
         self.client = client
@@ -206,6 +242,58 @@ class FMAzureVirtualNetwork(FMVirtualNetwork):
         if assign_domain_name:
             self.vn_data["dnsStrategy"] = "VN_SPECIFIC_CLOUD_DNS_SERVICE"
             self.vn_data["azureDnsZoneId"] = azure_dns_zone_id
+        else:
+            self.vn_data["dnsStrategy"] = "NONE"
+
+        return self
+
+
+class FMGCPVirtualNetwork(FMVirtualNetwork):
+
+    def set_assign_public_ip(self, public_ip=True):
+        """
+        Sets whether the instances on this network will have a publicly accessible IP
+
+        :param bool public_ip: if False, the instances will not be accessible from outside GCP
+        """
+
+        if public_ip is not None:
+            self.vn_data["gcpAssignPublicIP"] = public_ip
+        return self
+
+    def set_location_for_created_resources(self, project_id=None,zone=None):
+        """
+        Set the location in GCP of the instances created using this virtual network
+
+        :param str project_id: Optional, the project in which instances should be created. If empty string, then the project 
+                               of the FM instance is used
+        :param str zone: Optional, the zone in which instances should be created. If empty string, then the zone 
+                         of the FM instance is used
+        """
+
+        if zone == '':
+            self.vn_data["gcpZone"] = None
+        elif zone is not None:
+            self.vn_data["gcpZone"] = zone
+        if project_id == '':
+            self.vn_data["gcpProjectIdForCreatedResources"] = None
+        elif project_id is not None:
+            self.vn_data["gcpProjectIdForCreatedResources"] = project_id
+        return self
+
+    def set_dns_strategy(self, assign_domain_name, private_ip_zone_id=None,public_ip_zone_id=None):
+        """
+        Set the DNS strategy for this virtual network
+
+        :param boolean assign_domain_name: If false, don't assign domain names, use ip_only
+        :param str private_ip_zone_id: Optional, the ID of the Cloud DNS Zone to use for private ip
+        :param str public_ip_zone_id: Optional, the ID of the Cloud DNS Zone to use for public ip
+        """
+
+        if assign_domain_name:
+            self.vn_data["dnsStrategy"] = "VN_SPECIFIC_CLOUD_DNS_SERVICE"
+            self.vn_data["gcpCloudDnsPrivateIPZoneId"] = private_ip_zone_id
+            self.vn_data["gcpCloudDnsPublicIPZoneId"] = public_ip_zone_id
         else:
             self.vn_data["dnsStrategy"] = "NONE"
 

--- a/dataikuapi/fmclient.py
+++ b/dataikuapi/fmclient.py
@@ -11,21 +11,26 @@ from .fm.virtualnetworks import (
     FMVirtualNetwork,
     FMAWSVirtualNetworkCreator,
     FMAzureVirtualNetworkCreator,
+    FMGCPVirtualNetworkCreator,
     FMAWSVirtualNetwork,
     FMAzureVirtualNetwork,
+    FMGCPVirtualNetwork
 )
 from .fm.instances import (
     FMInstance,
     FMInstanceEncryptionMode,
     FMAWSInstanceCreator,
     FMAzureInstanceCreator,
+    FMGCPInstanceCreator,
     FMAWSInstance,
     FMAzureInstance,
+    FMGCPInstance
 )
 from .fm.instancesettingstemplates import (
     FMInstanceSettingsTemplate,
     FMAWSInstanceSettingsTemplateCreator,
     FMAzureInstanceSettingsTemplateCreator,
+    FMGCPInstanceSettingsTemplateCreator
 )
 
 import sys
@@ -49,11 +54,11 @@ class FMClient(object):
     ):
         """
         Base class for the different FM Clients
-        Do not create this class, instead use :class:`dataikuapi.FMClientAWS` or :class:`dataikuapi.FMClientAzure`
+        Do not create this class, instead use :class:`dataikuapi.FMClientAWS`, :class:`dataikuapi.FMClientAzure` or :class:`dataikuapi.FMClientGCP`
         """
         if self.cloud == None:
             raise NotImplementedError(
-                "Do not use FMClient directly, instead use FMClientAWS or FMClientAzure"
+                "Do not use FMClient directly, instead use FMClientAWS, FMClientAzure or FMClientGCP"
             )
         self.api_key_id = api_key_id
         self.api_key_secret = api_key_secret
@@ -104,6 +109,8 @@ class FMClient(object):
             return FMAWSVirtualNetwork(self, vn)
         elif self.cloud == "Azure":
             return FMAzureVirtualNetwork(self, vn)
+        elif self.cloud == "GCP":
+            return FMGCPVirtualNetwork(self, vn)
         else:
             raise Exception("Unknown cloud type %s" % self.cloud)
 
@@ -168,6 +175,8 @@ class FMClient(object):
             return FMAWSInstance(self, i)
         elif self.cloud == "Azure":
             return FMAzureInstance(self, i)
+        elif self.cloud == "GCP":
+            return FMGCPInstance(self, i)
         else:
             raise Exception("Unknown cloud type %s" % self.cloud)
 
@@ -407,5 +416,62 @@ class FMClientAzure(FMClient):
         :rtype: :class:`dataikuapi.fm.instances.FMAzureInstanceCreator`
         """
         return FMAzureInstanceCreator(
+            self, label, instance_settings_template_id, virtual_network_id, image_id
+        )
+
+class FMClientGCP(FMClient):
+    def __init__(
+        self,
+        host,
+        api_key_id,
+        api_key_secret,
+        tenant_id="main",
+        extra_headers=None,
+    ):
+        """
+        GCP Only - Instantiate a new FM API client on the given host with the given API key.
+
+        API keys can be managed in FM on the project page or in the global settings.
+
+        The API key will define which operations are allowed for the client.
+
+        :param str host: Full url of the FM
+        """
+        self.cloud = "GCP"
+        super(FMClientGCP, self).__init__(
+            host, api_key_id, api_key_secret, tenant_id, extra_headers
+        )
+
+    def new_virtual_network_creator(self, label):
+        """
+        Instantiate a new virtual network creator
+
+        :param str label: The label of the
+        :rtype: :class:`dataikuapi.fm.virtualnetworks.FMGCPVirtualNetworkCreator`
+        """
+        return FMGCPVirtualNetworkCreator(self, label)
+
+    def new_instance_template_creator(self, label):
+        """
+        Instantiate a new instance template creator
+
+        :param str label: The label of the instance
+        :rtype: :class:`dataikuapi.fm.instancesettingstemplates.FMGCPInstanceSettingsTemplateCreator`
+        """
+        return FMGCPInstanceSettingsTemplateCreator(self, label)
+
+    def new_instance_creator(
+        self, label, instance_settings_template_id, virtual_network_id, image_id
+    ):
+        """
+        Instantiate a new instance creator
+
+        :param str label: The label of the instance
+        :param str instance_settings_template: The instance settings template id this instance should be based on
+        :param str virtual_network: The virtual network where the instance should be spawned
+        :param str image_id: The ID of the DSS runtime image (ex: dss-9.0.3-default)
+        :rtype: :class:`dataikuapi.fm.instances.FMGCPInstanceCreator`
+        """
+        return FMGCPInstanceCreator(
             self, label, instance_settings_template_id, virtual_network_id, image_id
         )


### PR DESCRIPTION
[sc-85516]

use the associated PR in dataiku/dip, for the virtual network handling of default values

example
```
url = "https://gcp-fm-deploy"
key_id = "Mky3Q3pmLNdyxpTc"
key_secret = "OpZVEWNe1pJWQdZ0kPATKbn2aDsyFaSf"
client = dataikuapi.FMClientGCP(url, key_id, key_secret)
client._session.verify = None

istc = client.new_instance_template_creator("from api")
istc.with_ssh_key("ssh-rsa hohooho")
istc.with_block_project_wide_keys(False)
istc.with_restrict_metadata_server_access(True)
istc.with_runtime_service_account("foo@bar.com")
ist = istc.create()

ist.delete()

vnetc = client.new_virtual_network_creator("from api")
vnetc.with_default_values()
#vnetc.with_vpc("fchataigner-dev", "fm-network", "fm-subnetwork")
vnetc.with_network_tags("from", "api")
vnet = vnetc.create()

vnet.set_assign_public_ip(True)
vnet.set_location_for_created_resources(None, '')
vnet.set_dns_strategy(False, 'tiger')
vnet.save()

vnet.delete()

ic = client.new_instance_creator('from api', 'ist-x6dgQrtBaZIX', 'vn-ekfisydfe6fu', 'dss-11.0.0-default')
ic.with_cloud_instance_type('n1-standard-4')
ic.with_cloud_tags([{"key":"foo", "value":"bar"}])
ic.with_dss_node_type("automation")
ic.with_data_volume_options('pd-balanced', 42, 430, None, dataikuapi.fm.instances.FMInstanceEncryptionMode.DEFAULT_KEY, 'hohoho')
i = ic.create()

i.set_public_ip(True, 'pip')
i.save()

i.delete()

```
