### PR TITLE
Add ability to create a DSS client from FM client

### DIFF
--- a/dataikuapi/fm/instances.py
+++ b/dataikuapi/fm/instances.py
@@ -195,7 +195,7 @@ class FMInstance(object):
         """
         instance_status = self.get_status()
         public_url = instance_status.get("publicURL")
-        api_key = self.instance_data.get('adminAPIKey')
+        api_key = self.instance_data.get("adminAPIKey")
 
         if self.instance_data.get("dssNodeType") == "govern":
             # TODO waiting for PR merge to be uncommented

--- a/dataikuapi/fm/instances.py
+++ b/dataikuapi/fm/instances.py
@@ -1,5 +1,8 @@
 from .future import FMFuture
 
+from ..dssclient import DSSClient
+# from ..governclient import GovernClient
+
 import sys
 
 if sys.version_info > (3, 4):
@@ -182,6 +185,31 @@ class FMInstance(object):
         self.client = client
         self.instance_data = instance_data
         self.id = instance_data["id"]
+
+    def get_client(self, instance_id, api_key):
+        """
+        Get a Python client to communicate with a DSS instance
+
+        :param str instance_id: The target DSS instance ID
+        :param str api_key: The API key generated from the target DSS instance
+
+        :return: a Python client to communicate with the target instance
+        :rtype: :class:`dataikuapi.dssclient.DSSClient`
+        """
+        instance = self.client.get_instance(instance_id)
+        instance_status = instance.get_status()
+        public_url = instance_status.get("publicURL")
+
+        if instance.instance_data.get("dssNodeType") == "govern":
+            # TODO waiting for PR merge to be uncommented
+            # https://github.com/dataiku/dataiku-api-client-python/pull/245
+            raise Exception("DSS client for Govern nodes is not available")
+            # return GovernClient(public_url, api_key)
+
+        if not public_url:
+            raise ValueError("No public URL available for node %s. This node may not be provisioned yet" % instance_id)
+
+        return DSSClient(public_url, api_key)
 
     def reprovision(self):
         """

--- a/dataikuapi/fm/instances.py
+++ b/dataikuapi/fm/instances.py
@@ -186,21 +186,18 @@ class FMInstance(object):
         self.instance_data = instance_data
         self.id = instance_data["id"]
 
-    def get_client(self, instance_id, api_key):
+    def get_client(self):
         """
         Get a Python client to communicate with a DSS instance
-
-        :param str instance_id: The target DSS instance ID
-        :param str api_key: The API key generated from the target DSS instance
 
         :return: a Python client to communicate with the target instance
         :rtype: :class:`dataikuapi.dssclient.DSSClient`
         """
-        instance = self.client.get_instance(instance_id)
-        instance_status = instance.get_status()
+        instance_status = self.get_status()
         public_url = instance_status.get("publicURL")
+        api_key = self.instance_data.get('adminAPIKey')
 
-        if instance.instance_data.get("dssNodeType") == "govern":
+        if self.instance_data.get("dssNodeType") == "govern":
             # TODO waiting for PR merge to be uncommented
             # https://github.com/dataiku/dataiku-api-client-python/pull/245
             raise Exception("DSS client for Govern nodes is not available")

--- a/dataikuapi/fmclient.py
+++ b/dataikuapi/fmclient.py
@@ -227,9 +227,10 @@ class FMClient(object):
         instance_status = instance.get_status()
         public_url = instance_status.get("publicURL")
 
-        # TODO waiting for PR merge to be uncommented
-        # https://github.com/dataiku/dataiku-api-client-python/pull/245
-        # if instance.instance_data.get("nodeType") == "govern":
+        if instance.instance_data.get("nodeType") == "govern":
+            # TODO waiting for PR merge to be uncommented
+            # https://github.com/dataiku/dataiku-api-client-python/pull/245
+            raise Exception("DSS client for Govern nodes is not available")
             # return GovernClient(public_url, api_key)
 
         return DSSClient(public_url, api_key)

--- a/dataikuapi/fmclient.py
+++ b/dataikuapi/fmclient.py
@@ -228,7 +228,7 @@ class FMClient(object):
         public_url = instance_status.get("publicURL")
 
         if not public_url:
-            raise ValueError("No public URL available. This node may not be provisioned yet")
+            raise ValueError("No public URL available for node %s. This node may not be provisioned yet" % instance_id)
 
         if instance.instance_data.get("nodeType") == "govern":
             # TODO waiting for PR merge to be uncommented

--- a/dataikuapi/fmclient.py
+++ b/dataikuapi/fmclient.py
@@ -213,31 +213,6 @@ class FMClient(object):
         """
         return self._perform_tenant_json("GET", "/images")
 
-    def get_instance_client(self, instance_id, api_key):
-        """
-        Get a Python client to communicate with an instance
-
-        :param str instance_id: The instance ID
-        :param str api_key: The API key generated from the target DSS instance
-
-        :return: a Python client to communicate with the target instance
-        :rtype: :class:`dataikuapi.dssclient.DSSClient`
-        """
-        instance = self.get_instance(instance_id)
-        instance_status = instance.get_status()
-        public_url = instance_status.get("publicURL")
-
-        if not public_url:
-            raise ValueError("No public URL available for node %s. This node may not be provisioned yet" % instance_id)
-
-        if instance.instance_data.get("nodeType") == "govern":
-            # TODO waiting for PR merge to be uncommented
-            # https://github.com/dataiku/dataiku-api-client-python/pull/245
-            raise Exception("DSS client for Govern nodes is not available")
-            # return GovernClient(public_url, api_key)
-
-        return DSSClient(public_url, api_key)
-
     ########################################################
     # Internal Request handling
     ########################################################

--- a/dataikuapi/fmclient.py
+++ b/dataikuapi/fmclient.py
@@ -4,6 +4,9 @@ from requests import exceptions
 from requests.auth import HTTPBasicAuth
 import os.path as osp
 
+from .dssclient import DSSClient
+# from .governclient import GovernClient
+
 from .utils import DataikuException
 
 from .fm.tenant import FMCloudCredentials, FMCloudTags
@@ -209,6 +212,27 @@ class FMClient(object):
         :return: list of images, as a pair of id and label
         """
         return self._perform_tenant_json("GET", "/images")
+
+    def get_instance_client(self, instance_id, api_key):
+        """
+        Get a Python client to communicate with an instance
+
+        :param str instance_id: The instance ID
+        :param str api_key: The API key generated from the target DSS instance
+
+        :return: a Python client to communicate with the target instance
+        :rtype: :class:`dataikuapi.dssclient.DSSClient`
+        """
+        instance = self.get_instance(instance_id)
+        instance_status = instance.get_status()
+        public_url = instance_status.get("publicURL")
+
+        # TODO waiting for PR merge to be uncommented
+        # https://github.com/dataiku/dataiku-api-client-python/pull/245
+        # if instance.instance_data.get("nodeType") == "govern":
+            # return GovernClient(public_url, api_key)
+
+        return DSSClient(public_url, api_key)
 
     ########################################################
     # Internal Request handling

--- a/dataikuapi/fmclient.py
+++ b/dataikuapi/fmclient.py
@@ -227,6 +227,9 @@ class FMClient(object):
         instance_status = instance.get_status()
         public_url = instance_status.get("publicURL")
 
+        if not public_url:
+            raise ValueError("No public URL available. This node may not be provisioned yet")
+
         if instance.instance_data.get("nodeType") == "govern":
             # TODO waiting for PR merge to be uncommented
             # https://github.com/dataiku/dataiku-api-client-python/pull/245

--- a/dataikuapi/fmclient.py
+++ b/dataikuapi/fmclient.py
@@ -4,9 +4,6 @@ from requests import exceptions
 from requests.auth import HTTPBasicAuth
 import os.path as osp
 
-from .dssclient import DSSClient
-# from .governclient import GovernClient
-
 from .utils import DataikuException
 
 from .fm.tenant import FMCloudCredentials, FMCloudTags


### PR DESCRIPTION
[sc-95097]

Be able to create a DSS client using the node ID and an API key authorized on this node in order to perform actions on the DSS instance.

This PR is paired with [dip PR](https://github.com/dataiku/dip/pull/17499).