### PR TITLE
Path issue windows mlflow plugin

### DIFF
--- a/dataikuapi/dss/managedfolder.py
+++ b/dataikuapi/dss/managedfolder.py
@@ -116,14 +116,14 @@ class DSSManagedFolder(object):
         Note: upload_folder("target", "source") will result in "target" containing the content
         of "source", not in "target" containing "source".
 
-        :param str path: the destination path of the folder in the managed folder
+        :param str path: the destination path of the folder in the managed folder (POSIX)
         :param str folder: path  (absolute or relative) of the source folder to upload
         """
         for root, _, files in os.walk(folder):
             for file in files:
                 filename = os.path.join(root, file)
                 with open(filename, "rb") as f:
-                    rel_posix_path = os.path.relpath(filename, folder).replace("\\", "/")
+                    rel_posix_path = "/".join(os.path.relpath(filename, folder).split(os.sep))
                     self.put_file("{}/{}".format(path, rel_posix_path), f)
 
     ########################################################

--- a/dataikuapi/dss/managedfolder.py
+++ b/dataikuapi/dss/managedfolder.py
@@ -123,7 +123,8 @@ class DSSManagedFolder(object):
             for file in files:
                 filename = os.path.join(root, file)
                 with open(filename, "rb") as f:
-                    self.put_file(os.path.join(path, os.path.relpath(filename, folder)), f)
+                    rel_posix_path = os.path.relpath(filename, folder).replace("\\", "/")
+                    self.put_file("{}/{}".format(path, rel_posix_path), f)
 
     ########################################################
     # Managed folder actions


### PR DESCRIPTION
Changes
---------
-> Use PurePosixPath to manipulate paths in artifact folder on MLflow artifact_repository plugin

-> Make DSSManagedFolder.upload_folder work on windows
For this we used the string method replace to replace backslashes with normal slashes because
1. we work with relative path (so no prefix "C:/" for instance)
2. we don't know if pathlib is installed since we support python2.7 (whereas in the MLflow plugin part we need MLflow, hence python >= 3.6 where pathlib is builtin)

Testing
-------
Companion test PR: https://github.com/dataiku/dip/pull/17453 with the DOD there

To test on windows you can install the kit and directly edit the dataikuapi in the kit as suggested by @lpenet here: https://app.shortcut.com/dataiku/story/92017/experiment-tracking-does-not-work-on-windows
