### PR TITLE
MlflowHandle with managed_folder.get_id() instead of name when it is a Folder

### DIFF
--- a/dataikuapi/dss_plugin_mlflow/utils.py
+++ b/dataikuapi/dss_plugin_mlflow/utils.py
@@ -76,7 +76,7 @@ class MLflowHandle:
             try:
                 from dataiku import Folder
                 if isinstance(managed_folder, Folder):
-                    mf_full_id = managed_folder.name
+                    mf_full_id = managed_folder.get_id()
             except ImportError:
                 pass
 


### PR DESCRIPTION
Prior to this, the following snippet was not working
1/ Create a folder named "Tracking" in DSS
2/ Execute in a notebook, using an MLflow enabled code env 
```
import dataiku
exp_tracking_folder = dataiku.Folder("Tracking") # looking by name, not id
exp_tracking_folder.get_info()
dataiku.api_client().get_default_project().setup_mlflow(managed_folder=exp_tracking_folder)
```
