### PR TITLE
[sc-92338] smoother polling strategy

### DIFF
--- a/dataikuapi/dss/job.py
+++ b/dataikuapi/dss/job.py
@@ -55,8 +55,8 @@ class DSSJobWaiter(object):
         job_state = self.job.get_status().get("baseStatus", {}).get("state", "")
         sleep_time = 2
         while job_state not in ["DONE", "ABORTED", "FAILED"]:
-            sleep_time = 300 if sleep_time >= 300 else sleep_time * 2
-            time.sleep(sleep_time)
+            sleep_time = 60 if sleep_time >= 60 else sleep_time * 1.2
+            time.sleep(int(sleep_time))
             job_state = self.job.get_status().get("baseStatus", {}).get("state", "")
             if job_state in ["ABORTED", "FAILED"]:
                 if no_fail:


### PR DESCRIPTION
I actually did the math (and some live tests) because I thought a factor 2 was a bit too aggressive. And indeed, an unlucky job taking roughly 127 secondes will fall just after the polling request (between iter_5 and iter_6 in the first table below), and thus will gain an extra 124 seconds of waiting time... so almost 100﹪ extra time for a 2 minutes job. Here are tables with the waiting counter and the elapsed time.

1. before the fix, max at 300, factor 2

| iter | wait | elapsed |
|------|------|---------|
| 0    | 2    |       2 |
| 1    | 4    |       6 |
| 2    | 8    |      14 |
| 3    | 16   |      30 |
| 4    | 32   |      62 |
| 5    | 64   |     126 |
| 6    | 128  |     254 |
| 7    | 256  |     510 |
| 8    | 512  |    1022 |
| 9    | 300  |    1322 |
| 10   | 300  |    1622 |

2. max at 60, factor 2

| iter | wait | elapsed |
|------|------|---------|
| 0    | 2    |       2 |
| 1    | 4    |       6 |
| 2    | 8    |      14 |
| 3    | 16   |      30 |
| 4    | 32   |      62 |
| 5    | 64   |     126 |
| 6    | 60   |     186 |
| 7    | 60   |     246 |
| 8    | 60   |     306 |
| 9    | 60   |     366 |
| 10   | 60   |     426 |

3. max at 60, factor 1.2

| iter | wait | elapsed |
|------|------|---------|
| 0    | 2    |       2 |
| 1    | 2    |       4 |
| 2    | 2    |       6 |
| 3    | 3    |       9 |
| 4    | 4    |      13 |
| 5    | 4    |      17 |
| 6    | 5    |      22 |
| 7    | 7    |      29 |
| 8    | 8    |      37 |
| 9    | 10   |      47 |
| 10   | 12   |      59 |

# How to reproduce (if not obvious enough)

Here is the *complex* Python recipe I used to test the API:

```python
# -*- coding: utf-8 -*-
import dataiku
import pandas as pd, numpy as np
from dataiku import pandasutils as pdu

# Read recipe inputs
umm = dataiku.Dataset("umm")
umm_df = umm.get_dataframe()

umm2_df = umm_df # For this sample code, simply copy input to output

# See what I did here? :) 
import time
time.sleep(128)

# Write recipe outputs
umm2 = dataiku.Dataset("umm2")
umm2.write_with_schema(umm2_df)
```

And here is the python code I used to trigger the job and mesure the elapsed time:

```python
import dataiku
from dataikuapi import DSSClient
import time

client = dataiku.api_client()
project = client.get_project("SC92338")

start = time.time()
project.get_recipe("compute_umm2").run()
end = time.time()
print("elapsed: ", end - start)
```

For this recipe, here are the elapsed time, for a job taking actually around 140 seconds:
- before the fix -> 253 s
- max waiting time at 60s -> 185s
- max waiting time at 60s + smoother factor (1.2) -> 168s

We could use a more linear polling strategy but I guess this is enough.