### PR TITLE
99387 : support creating a govern node

### DIFF
--- a/dataikuapi/fm/instances.py
+++ b/dataikuapi/fm/instances.py
@@ -37,14 +37,12 @@ class FMInstanceCreator(object):
         """
         Set the DSS Node type of the instance to create
 
-        :param str dss_node_type: Optional , the type of the dss node to create. Supports "design", "automation ordeployer". Defaults to "design"
+        :param str dss_node_type: Optional , the type of the dss node to create. Defaults to `DESIGN`.
+        :type dss_nodetype: :class:`dataikuapi.fm.instances.FMNodeType`
         :rtype: :class:`dataikuapi.fm.instances.FMInstanceCreator`
         """
-        if dss_node_type not in ["design", "automation", "deployer"]:
-            raise ValueError(
-                'Only "design", "automation" or "deployer" dss_node_type are supported'
-            )
-        self.data["dssNodeType"] = dss_node_type
+
+        self.data["dssNodeType"] = dss_node_type.value
         return self
 
     def with_cloud_instance_type(self, cloud_instance_type):
@@ -389,6 +387,11 @@ class FMGCPInstance(FMInstance):
         self.instance_data["gcpPublicIPId"] = public_ip_id
         return self
 
+class FMNodeType(Enum):
+    DESIGN = "design"
+    DEPLOYER = "deployer"
+    AUTOMATION = "automation"
+    GOVERN = "govern"
 
 class FMInstanceEncryptionMode(Enum):
     NONE = "NONE"

--- a/dataikuapi/fm/instances.py
+++ b/dataikuapi/fm/instances.py
@@ -15,7 +15,7 @@ class FMInstanceCreator(object):
         self, client, label, instance_settings_template_id, virtual_network_id, image_id
     ):
         """
-        Helper to create a DSS Instance
+        Helper to create a DSS instance.
 
         :param object client: :class:`dataikuapi.fm.fmclient`
         :param str label: The label of the instance
@@ -35,14 +35,17 @@ class FMInstanceCreator(object):
 
     def with_dss_node_type(self, dss_node_type):
         """
-        Set the DSS Node type of the instance to create
+        Set the DSS node type of the instance to create. The default node type is `DESIGN`.
 
-        :param dss_node_type: Optional , the type of the dss node to create. Defaults to `DESIGN`.
+        :param dss_node_type: the type of the dss node to create.
         :type dss_node_type: :class:`dataikuapi.fm.instances.FMNodeType`
         :rtype: :class:`dataikuapi.fm.instances.FMInstanceCreator`
         """
-
-        self.data["dssNodeType"] = dss_node_type.value
+        # backward compatibility, was a string before . be sure the value falls into the enum
+        value = dss_node_type;
+        if isinstance(dss_node_type, str):
+            value = FMNodeType[dss_node_type.upper()]
+        self.data["dssNodeType"] = value.value
         return self
 
     def with_cloud_instance_type(self, cloud_instance_type):

--- a/dataikuapi/fm/instances.py
+++ b/dataikuapi/fm/instances.py
@@ -37,8 +37,8 @@ class FMInstanceCreator(object):
         """
         Set the DSS Node type of the instance to create
 
-        :param str dss_node_type: Optional , the type of the dss node to create. Defaults to `DESIGN`.
-        :type dss_nodetype: :class:`dataikuapi.fm.instances.FMNodeType`
+        :param dss_node_type: Optional , the type of the dss node to create. Defaults to `DESIGN`.
+        :type dss_node_type: :class:`dataikuapi.fm.instances.FMNodeType`
         :rtype: :class:`dataikuapi.fm.instances.FMInstanceCreator`
         """
 

--- a/dataikuapi/fm/virtualnetworks.py
+++ b/dataikuapi/fm/virtualnetworks.py
@@ -176,7 +176,7 @@ class FMVirtualNetwork(object):
         return FMFuture.from_resp(self.client, future)
 
     def set_fleet_management(
-        self, enable, event_server=None, deployer_management="NO_MANAGED_DEPLOYER"
+        self, enable, event_server=None, deployer_management="NO_MANAGED_DEPLOYER", govern_server=None
     ):
         """
         When enabled, all instances in this virtual network know each other and can centrally manage deployer and logs centralization
@@ -185,14 +185,17 @@ class FMVirtualNetwork(object):
 
         :param str event_server: Optional,  Node name of the node that should act as the centralized event server for logs concentration. Audit logs of all design, deployer and automation nodes will automatically be sent there.
         :param str deployer_management: Optional, Accepts:
-            - "NO_MANAGED_DEPLOYER": Do not manage the the deployer. This is the default mode.
-            - "CENTRAL_DEPLOYER": Central deployer. Recommanded if you have more than one design node or may have more than one design node in the future.
-            - "EACH_DESIGN_NODE": Deployer from design. Recommanded if you have a single design node and want a simpler setup.
+            - "NO_MANAGED_DEPLOYER": Do not manage the deployer. This is the default mode.
+            - "CENTRAL_DEPLOYER": Central deployer. Recommended if you have more than one design node or may have more than one design node in the future.
+            - "EACH_DESIGN_NODE": Deployer from design. Recommended if you have a single design node and want a simpler setup.
+        :param str govern_server: Optional, node name of the node that should act as the centralized Govern server.
+
         """
 
         self.vn_data["managedNodesDirectory"] = enable
         self.vn_data["eventServerNodeLabel"] = event_server
         self.vn_data["nodesDirectoryDeployerMode"] = deployer_management
+        self.vn_data["governServerNodeLabel"] = govern_server
         return self
 
     def set_https_strategy(self, https_strategy):


### PR DESCRIPTION

 add support for govern node creation

`
client = dataikuapi.FMClientAWS ("https://somewhere", "key", "secret")
client._session.verify = None

creator = client.new_virtual_network_creator ("MyNetwork")
creator.with_vpc ("vpc-xxx", "subnet-yyy")
netw = creator.create ()
netw.set_fleet_management (True, govern_server="Governor")
netw.save()
`
`
creator = client.new_instance_creator("MyGovernInstance", "ist-IJcznImxJFTI", "vn-xWfdn88cADov", "dss-11.0.2-default")
creator.with_dss_node_type(dataikuapi.fm.instances.FMNodeType.GOVERN).with_cloud_instance_type("m5a.2xlarge")
dss = creator.create ()
`